### PR TITLE
Implement analyse workflow with tests

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -1,4 +1,5 @@
 import typer
+from pathlib import Path
 
 from .io.loader import load_transactions
 from .reports.writer import write_summary
@@ -6,9 +7,19 @@ from .settings import get_settings
 
 app = typer.Typer(help="BankCleanr CLI")
 
+# Path to a sample statement used for demonstrations
+SAMPLE_STATEMENT = (
+    Path(__file__).resolve().parent.parent
+    / "Redacted bank statements"
+    / "22b583f5-4060-44eb-a844-945cd612353c (1).pdf"
+)
+
 
 @app.command()
-def analyse(file: str, output: str = "summary.csv"):
+def analyse(
+    file: str = typer.Argument(str(SAMPLE_STATEMENT)),
+    output: str = "summary.csv",
+):
     """Analyse a statement file and write a summary."""
     typer.echo(f"Analysing {file}")
     transactions = load_transactions(file)

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -2,3 +2,9 @@ Feature: Command-line interface
   Scenario: Show config path
     When I run the bankcleanr config command
     Then the exit code is 0
+
+  Scenario: Analyse a PDF statement
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf"
+    Then the exit code is 0
+    And the summary file exists
+    And the summary contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -1,5 +1,7 @@
 from behave import when, then
 import subprocess
+from pathlib import Path
+from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
 
 @when('I run the bankcleanr config command')
 def run_config(context):
@@ -8,3 +10,27 @@ def run_config(context):
 @then('the exit code is 0')
 def check_exit(context):
     assert context.result.returncode == 0
+
+
+@when('I run the bankcleanr analyse command with "{pdf}"')
+def run_analyse(context, pdf):
+    root = Path(__file__).resolve().parents[2]
+    context.summary_path = root / "summary.csv"
+    if context.summary_path.exists():
+        context.summary_path.unlink()
+    context.result = subprocess.run(
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf)],
+        capture_output=True,
+        cwd=root,
+    )
+
+
+@then('the summary file exists')
+def summary_exists(context):
+    assert context.summary_path.exists()
+
+
+@then('the summary contains the disclaimer')
+def summary_contains_disclaimer(context):
+    text = context.summary_path.read_text()
+    assert GLOBAL_DISCLAIMER in text

--- a/tests/test_io_writer.py
+++ b/tests/test_io_writer.py
@@ -1,0 +1,43 @@
+import csv
+import pytest
+
+from bankcleanr.io.loader import load_transactions
+from bankcleanr.reports.writer import write_summary
+from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
+
+
+def test_load_transactions_pdf_dispatch(monkeypatch):
+    called = {}
+
+    def fake_parse(path):
+        called["path"] = path
+        return [{"a": 1}]
+
+    monkeypatch.setattr("bankcleanr.io.pdf.generic.parse_pdf", fake_parse)
+    result = load_transactions("statement.pdf")
+    assert result == [{"a": 1}]
+    assert called["path"] == "statement.pdf"
+
+
+def test_load_transactions_unsupported():
+    with pytest.raises(ValueError):
+        load_transactions("statement.txt")
+
+
+def test_write_summary(tmp_path):
+    transactions = [
+        {"date": "2023-01-01", "description": "Coffee", "amount": "-1.00", "balance": "99.00"},
+        {"date": "2023-01-02", "description": "Tea", "amount": "-2.00", "balance": "97.00"},
+    ]
+    output = tmp_path / "summary.csv"
+    path = write_summary(transactions, str(output))
+    assert path == output
+
+    with output.open() as f:
+        rows = list(csv.reader(f))
+
+    assert rows[0] == ["date", "description", "amount", "balance"]
+    assert rows[1] == ["2023-01-01", "Coffee", "-1.00", "99.00"]
+    assert rows[2] == ["2023-01-02", "Tea", "-2.00", "97.00"]
+    assert rows[3] == []
+    assert rows[4] == [GLOBAL_DISCLAIMER]


### PR DESCRIPTION
## Summary
- default `analyse` statement to a sample PDF
- check CLI functionality with new Behave scenario
- verify I/O helpers with unit tests

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6861226c9c0c832b9d9a70611c951e34