### PR TITLE
Add Poetry configuration and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+summary.csv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # dogshit
-Look through your bank statements and call LLM for each item and then advised to keep or cancel with explanation on how to do it.
+
+A simple tool for analysing bank statements using various LLM adapters. It ships a
+command line interface and a small test-suite.
+
+## Setup with Poetry
+
+1. [Install Poetry](https://python-poetry.org/docs/#installation).
+2. Create the virtual environment and install dependencies:
+
+   ```bash
+   poetry install
+   ```
+
+## Running the tests
+
+Run the unit tests with `pytest` and the behaviour driven tests with `behave`:
+
+```bash
+poetry run pytest
+poetry run behave
+```
+
+## Running the application
+
+You can invoke the CLI through Poetry:
+
+```bash
+poetry run bankcleanr config
+poetry run bankcleanr analyse path/to/statement.pdf
+```
+
+The `analyse` command writes a `summary.csv` to the working directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.poetry]
+name = "bankcleanr"
+version = "0.1.0"
+description = "Bank statement analyser"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+packages = [{ include = "bankcleanr" }]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+typer = "^0.12.3"
+PyYAML = "^6.0"
+pydantic = "^2.7.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.1.1"
+behave = "^1.2.6"
+
+[tool.poetry.scripts]
+bankcleanr = "bankcleanr.cli:app"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with Poetry configuration
- document Poetry workflow in the README
- ignore generated summary file

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68612835a864832bb30321fae86e58a8