### PR TITLE
Add transaction dataclass and local heuristics

### DIFF
--- a/bankcleanr/io/pdf/generic.py
+++ b/bankcleanr/io/pdf/generic.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import List, Mapping
 
+from bankcleanr.transaction import Transaction
+
 import pdfplumber
 
 LINE_RE = re.compile(
@@ -12,44 +14,44 @@ LINE_RE = re.compile(
 )
 
 
-def _parse_lines(lines: List[str]) -> List[Mapping[str, str]]:
-    """Parse lines of text into transaction dictionaries."""
+def _parse_lines(lines: List[str]) -> List[Transaction]:
+    """Parse lines of text into Transaction objects."""
     rows = []
     for line in lines:
         match = LINE_RE.match(line.strip())
         if match:
             data = match.groupdict()
             rows.append(
-                {
-                    "date": data.get("date", ""),
-                    "description": data.get("description", ""),
-                    "amount": data.get("amount", ""),
-                    "balance": data.get("balance", ""),
-                }
+                Transaction(
+                    date=data.get("date", ""),
+                    description=data.get("description", ""),
+                    amount=data.get("amount", ""),
+                    balance=data.get("balance", ""),
+                )
             )
     return rows
 
 
-def parse_pdf(path: str) -> List[Mapping[str, str]]:
+def parse_pdf(path: str) -> List[Transaction]:
     """Parse a bank statement PDF into transactions."""
-    transactions: List[Mapping[str, str]] = []
+    transactions: List[Transaction] = []
 
     try:
         with pdfplumber.open(path) as pdf:
             for page in pdf.pages:
                 table = page.extract_table()
-                parsed_rows: List[Mapping[str, str]] = []
+                parsed_rows: List[Transaction] = []
                 if table and len(table) > 1:
                     header, *body = table
                     for row in body:
                         if len(row) >= 4:
                             parsed_rows.append(
-                                {
-                                    "date": row[0].strip(),
-                                    "description": row[1].strip(),
-                                    "amount": row[2].strip(),
-                                    "balance": row[3].strip() if len(row) > 3 else "",
-                                }
+                                Transaction(
+                                    date=row[0].strip(),
+                                    description=row[1].strip(),
+                                    amount=row[2].strip(),
+                                    balance=row[3].strip() if len(row) > 3 else "",
+                                )
                             )
                     accuracy = len(parsed_rows) / (len(body) or 1)
                     if accuracy < 0.8:
@@ -64,7 +66,11 @@ def parse_pdf(path: str) -> List[Mapping[str, str]]:
     if not transactions:
         try:
             from . import ocr_fallback
-            transactions = ocr_fallback.parse_pdf(path)
+            fallback_rows = ocr_fallback.parse_pdf(path)
+            transactions = [
+                row if isinstance(row, Transaction) else Transaction.from_mapping(row)
+                for row in fallback_rows
+            ]
         except Exception:
             transactions = []
 

--- a/bankcleanr/reports/writer.py
+++ b/bankcleanr/reports/writer.py
@@ -1,16 +1,19 @@
 from pathlib import Path
 import csv
 from typing import Iterable, Mapping
+from dataclasses import asdict, is_dataclass
 from .disclaimers import GLOBAL_DISCLAIMER
 
 
-def write_summary(transactions: Iterable[Mapping], output: str) -> Path:
+def write_summary(transactions: Iterable, output: str) -> Path:
     """Write a minimal CSV summary including the disclaimer."""
     path = Path(output)
     with path.open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["date", "description", "amount", "balance"])
         for tx in transactions:
+            if is_dataclass(tx):
+                tx = asdict(tx)
             writer.writerow([
                 tx.get("date"),
                 tx.get("description"),

--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -1,0 +1,15 @@
+"""Local heuristics for quick transaction classification."""
+
+from typing import Iterable, List
+
+from bankcleanr.transaction import Transaction, normalise
+from . import regex
+
+
+def classify_transactions(transactions: Iterable) -> List[str]:
+    """Classify transactions locally using regex patterns."""
+    labels: List[str] = []
+    for tx in transactions:
+        tx_obj = normalise(tx)
+        labels.append(regex.classify(tx_obj.description))
+    return labels

--- a/bankcleanr/rules/regex.py
+++ b/bankcleanr/rules/regex.py
@@ -3,6 +3,7 @@ import re
 PATTERNS = {
     "spotify": re.compile(r"spotify", re.I),
     "netflix": re.compile(r"netflix", re.I),
+    "icloud": re.compile(r"icloud", re.I),
 }
 
 def classify(description: str) -> str:

--- a/bankcleanr/transaction.py
+++ b/bankcleanr/transaction.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, asdict, is_dataclass
+from typing import Mapping, Any
+
+@dataclass
+class Transaction:
+    date: str
+    description: str
+    amount: str
+    balance: str = ""
+
+    def to_dict(self) -> Mapping[str, Any]:
+        """Return transaction as a dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> 'Transaction':
+        """Create a Transaction from a mapping object."""
+        return cls(
+            date=data.get("date", ""),
+            description=data.get("description", ""),
+            amount=data.get("amount", ""),
+            balance=data.get("balance", ""),
+        )
+
+
+# utility to normalise
+
+def normalise(tx: Any) -> 'Transaction':
+    """Convert a dataclass or mapping into a Transaction."""
+    if is_dataclass(tx):
+        return tx  # type: ignore[return-value]
+    if isinstance(tx, Mapping):
+        return Transaction.from_mapping(tx)
+    raise TypeError("Unsupported transaction type")

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -1,0 +1,8 @@
+Feature: Local heuristics classification
+  Scenario: Tag obvious subscriptions
+    Given sample transactions
+    When I classify transactions locally
+    Then the labels are
+      | label   |
+      | spotify |
+      | unknown |

--- a/features/steps/heuristics_steps.py
+++ b/features/steps/heuristics_steps.py
@@ -1,0 +1,22 @@
+from behave import given, when, then
+from bankcleanr.transaction import Transaction
+from bankcleanr.rules.heuristics import classify_transactions
+
+
+@given("sample transactions")
+def given_transactions(context):
+    context.txs = [
+        Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
+        Transaction(date="2024-01-02", description="Coffee", amount="-2.00"),
+    ]
+
+
+@when("I classify transactions locally")
+def classify(context):
+    context.labels = classify_transactions(context.txs)
+
+
+@then("the labels are")
+def check_labels(context):
+    expected = [row[0] for row in context.table.rows]
+    assert context.labels == expected

--- a/features/steps/parser_steps.py
+++ b/features/steps/parser_steps.py
@@ -42,4 +42,4 @@ def parse_file(context):
 @then("the parser returns two transactions")
 def check_transactions(context):
     assert len(context.transactions) == 2
-    assert context.transactions[0]["description"] == "Coffee"
+    assert context.transactions[0].description == "Coffee"

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,0 +1,11 @@
+from bankcleanr.rules.heuristics import classify_transactions
+from bankcleanr.transaction import Transaction
+
+
+def test_classify_transactions():
+    txs = [
+        Transaction(date="2024-01-01", description="Spotify monthly", amount="-9.99"),
+        Transaction(date="2024-01-02", description="Coffee shop", amount="-2.50"),
+    ]
+    labels = classify_transactions(txs)
+    assert labels == ["spotify", "unknown"]

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -5,6 +5,7 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
 from bankcleanr.io.pdf import generic
+from bankcleanr.transaction import Transaction
 
 
 def _make_simple_pdf(rows):
@@ -33,8 +34,8 @@ def test_parse_pdf_regex():
         txs = generic.parse_pdf(path)
     finally:
         os.unlink(path)
-    assert txs[0]["description"] == "Coffee"
-    assert txs[1]["amount"] == "-2.00"
+    assert txs[0].description == "Coffee"
+    assert txs[1].amount == "-2.00"
 
 
 def test_parse_pdf_ocr_fallback(monkeypatch):
@@ -53,4 +54,5 @@ def test_parse_pdf_ocr_fallback(monkeypatch):
     monkeypatch.setitem(sys.modules, "bankcleanr.io.pdf.ocr_fallback", fake_mod)
     result = generic.parse_pdf("dummy.pdf")
     assert called.get("ocr")
-    assert result == [{"date": "01 Jan"}]
+    assert isinstance(result[0], Transaction)
+    assert result[0].date == "01 Jan"


### PR DESCRIPTION
## Summary
- normalize parsed transactions via `Transaction` dataclass
- extend regex patterns with an iCloud rule
- implement `classify_transactions` helper using local heuristics
- update PDF parser and writer for dataclasses
- add unit and behaviour tests for heuristics

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fcd65b1c832bb9da996c6eacc84d