### PR TITLE
Implement async LLM classification

### DIFF
--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Dict, Type
+
+from bankcleanr.settings import get_settings
+from bankcleanr.transaction import normalise, Transaction
+from bankcleanr.rules import heuristics
+
+from .base import AbstractAdapter
+from .openai import OpenAIAdapter
+from .anthropic import AnthropicAdapter
+from .mistral import MistralAdapter
+from .local_ollama import LocalOllamaAdapter
+
+# Mapping of provider names to adapter classes
+PROVIDERS: Dict[str, Type[AbstractAdapter]] = {
+    "openai": OpenAIAdapter,
+    "anthropic": AnthropicAdapter,
+    "mistral": MistralAdapter,
+    "ollama": LocalOllamaAdapter,
+}
+
+
+def get_adapter(provider: str | None = None) -> AbstractAdapter:
+    """Instantiate the adapter for the configured provider."""
+    provider = provider or get_settings().llm_provider
+    adapter_cls = PROVIDERS.get(provider, OpenAIAdapter)
+    return adapter_cls()
+
+
+def classify_transactions(transactions: Iterable, provider: str | None = None) -> List[str]:
+    """Classify transactions using heuristics and an optional LLM provider."""
+    tx_objs = [normalise(tx) for tx in transactions]
+    labels = heuristics.classify_transactions(tx_objs)
+
+    unmatched: List[Transaction] = []
+    unmatched_indexes: List[int] = []
+    for idx, (tx, label) in enumerate(zip(tx_objs, labels)):
+        if label == "unknown":
+            unmatched.append(tx)
+            unmatched_indexes.append(idx)
+
+    if unmatched:
+        adapter = get_adapter(provider)
+        llm_labels = adapter.classify_transactions(unmatched)
+        for idx, llm_label in zip(unmatched_indexes, llm_labels):
+            labels[idx] = llm_label
+
+    return labels

--- a/bankcleanr/llm/openai.py
+++ b/bankcleanr/llm/openai.py
@@ -1,8 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from tenacity import retry, wait_random_exponential, stop_after_attempt
+
 from .base import AbstractAdapter
+from bankcleanr.transaction import normalise, Transaction
+from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 
 class OpenAIAdapter(AbstractAdapter):
-    """Stub adapter for OpenAI API."""
+    """Adapter for OpenAI's chat models using LangChain."""
 
-    def classify_transactions(self, transactions):
-        return ["unknown" for _ in transactions]
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None):
+        self.llm = ChatOpenAI(model=model, api_key=api_key)
+
+    @retry(wait=wait_random_exponential(min=1, max=2), stop=stop_after_attempt(3))
+    async def _aclassify(self, tx: Transaction) -> str:
+        prompt = CATEGORY_PROMPT.render(description=tx.description)
+        message = HumanMessage(content=prompt)
+        result = await self.llm.apredict_messages([message])
+        return result.content.strip().lower()
+
+    async def _aclassify_batch(self, txs: Iterable[Transaction]) -> List[str]:
+        tasks = [self._aclassify(tx) for tx in txs]
+        return await asyncio.gather(*tasks)
+
+    def classify_transactions(self, transactions: Iterable) -> List[str]:
+        tx_objs = [normalise(tx) for tx in transactions]
+        return asyncio.run(self._aclassify_batch(tx_objs))

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -1,0 +1,9 @@
+Feature: LLM classification
+  Scenario: Fallback to OpenAI adapter for unknown items
+    Given transactions requiring LLM
+    And the OpenAI adapter is mocked to return "coffee"
+    When I classify transactions with the LLM
+    Then the LLM labels are
+      | label   |
+      | spotify |
+      | coffee  |

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -1,0 +1,39 @@
+from behave import given, when, then
+
+from bankcleanr.transaction import Transaction
+from bankcleanr.llm import classify_transactions, PROVIDERS
+from bankcleanr.llm.openai import OpenAIAdapter
+
+
+@given("transactions requiring LLM")
+def transactions_for_llm(context):
+    context.txs = [
+        Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
+        Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
+    ]
+
+
+@given('the OpenAI adapter is mocked to return "{label}"')
+def mock_adapter(context, label):
+    class DummyAdapter(OpenAIAdapter):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_transactions(self, transactions):
+            return [label for _ in transactions]
+
+    context.original = PROVIDERS["openai"]
+    PROVIDERS["openai"] = DummyAdapter
+
+
+@when("I classify transactions with the LLM")
+def classify_with_llm(context):
+    context.labels = classify_transactions(context.txs, provider="openai")
+
+
+@then("the LLM labels are")
+def check_labels(context):
+    expected = [row[0] for row in context.table.rows]
+    assert context.labels == expected
+    if hasattr(context, "original"):
+        PROVIDERS["openai"] = context.original

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ PyYAML = "^6.0"
 pydantic = "^2.7.0"
 pdfplumber = "^0.11.0"
 pytesseract = "^0.3.13"
+langchain-openai = "^0.3.27"
+langchain-core = "^0.3.67"
+openai = "^1.93.0"
+tenacity = "^9.1.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,20 @@
+from bankcleanr.llm import classify_transactions, PROVIDERS
+from bankcleanr.transaction import Transaction
+from bankcleanr.llm.openai import OpenAIAdapter
+
+class DummyAdapter(OpenAIAdapter):
+    def __init__(self, label="remote"):
+        self.label = label
+
+    def classify_transactions(self, transactions):
+        return [self.label for _ in transactions]
+
+
+def test_llm_fallback(monkeypatch):
+    monkeypatch.setitem(PROVIDERS, "openai", DummyAdapter)
+    txs = [
+        Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
+        Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
+    ]
+    labels = classify_transactions(txs, provider="openai")
+    assert labels == ["spotify", "remote"]


### PR DESCRIPTION
## Summary
- add OpenAI adapter implementation with LangChain
- route unknown items through chosen adapter in `llm.classify_transactions`
- expose new dependencies for LLM adapters
- test LLM fallback behaviour
- feature test for async LLM classification scenario

## Testing
- `pytest -q`
- `behave -q`


------
https://chatgpt.com/codex/tasks/task_e_68643bd541a8832baa26dcbdc732aa23