### PR TITLE
Add recommendation engine

### DIFF
--- a/bankcleanr/data/cancellation.yml
+++ b/bankcleanr/data/cancellation.yml
@@ -1,0 +1,12 @@
+spotify:
+  url: "https://support.spotify.com/how-to-cancel"
+  phone: ""
+  email: "support@spotify.com"
+netflix:
+  url: "https://help.netflix.com/en/node/407"
+  phone: ""
+  email: "support@netflix.com"
+icloud:
+  url: "https://support.apple.com/en-us/HT204084"
+  phone: ""
+  email: ""

--- a/bankcleanr/recommendation.py
+++ b/bankcleanr/recommendation.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+import yaml
+
+from .transaction import Transaction, normalise
+from .llm import classify_transactions
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+KB_PATH = DATA_DIR / "cancellation.yml"
+
+
+@dataclass
+class Recommendation:
+    transaction: Transaction
+    action: str
+    info: Dict[str, str] | None = None
+
+
+def load_knowledge_base(path: Path = KB_PATH) -> Dict[str, Dict[str, str]]:
+    """Load the cancellation knowledge-base."""
+    if path.exists():
+        return yaml.safe_load(path.read_text()) or {}
+    return {}
+
+
+def recommend_transactions(
+    transactions: Iterable,
+    provider: str | None = None,
+    kb_path: Path = KB_PATH,
+) -> List[Recommendation]:
+    """Return recommendations for each transaction."""
+    txs = [normalise(tx) for tx in transactions]
+    labels = classify_transactions(txs, provider=provider)
+    kb = load_knowledge_base(kb_path)
+    results: List[Recommendation] = []
+    for tx, label in zip(txs, labels):
+        if label in kb:
+            action = "Cancel"
+            info = kb[label]
+        elif label == "unknown":
+            action = "Investigate"
+            info = None
+        else:
+            action = "Keep"
+            info = None
+        results.append(Recommendation(tx, action, info))
+    return results

--- a/features/recommendation.feature
+++ b/features/recommendation.feature
@@ -1,0 +1,10 @@
+Feature: Recommendation engine
+  Scenario: Cancel known merchant using knowledge base
+    Given transactions requiring LLM
+    And the OpenAI adapter is mocked to return "coffee"
+    When I generate recommendations
+    Then the recommended actions are
+      | action |
+      | Cancel |
+      | Keep   |
+    And the first recommendation includes cancellation info

--- a/features/steps/recommendation_steps.py
+++ b/features/steps/recommendation_steps.py
@@ -1,0 +1,24 @@
+from behave import when, then
+
+from bankcleanr.llm import PROVIDERS
+from bankcleanr import recommendation
+
+
+@when("I generate recommendations")
+def generate_recommendations(context):
+    context.recommendations = recommendation.recommend_transactions(context.txs, provider="openai")
+    if hasattr(context, "original"):
+        PROVIDERS["openai"] = context.original
+
+
+@then("the recommended actions are")
+def check_actions(context):
+    expected = [row[0] for row in context.table.rows]
+    actions = [rec.action for rec in context.recommendations]
+    assert actions == expected
+
+
+@then("the first recommendation includes cancellation info")
+def first_has_info(context):
+    assert context.recommendations[0].info is not None
+    assert "url" in context.recommendations[0].info

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,0 +1,27 @@
+import yaml
+from bankcleanr.transaction import Transaction
+from bankcleanr.recommendation import load_knowledge_base, recommend_transactions
+
+
+def test_load_knowledge_base(tmp_path):
+    data = {"foo": {"url": "x"}}
+    path = tmp_path / "kb.yml"
+    path.write_text(yaml.safe_dump(data))
+    result = load_knowledge_base(path)
+    assert result == data
+
+
+def test_recommend_transactions(monkeypatch, tmp_path):
+    kb = {"spotify": {"url": "cancel"}}
+    kb_file = tmp_path / "kb.yml"
+    kb_file.write_text(yaml.safe_dump(kb))
+
+    txs = [Transaction(date="2024-01-01", description="Spotify", amount="-9.99")]
+
+    def dummy_classify(transactions, provider=None):
+        return ["spotify"]
+
+    monkeypatch.setattr("bankcleanr.recommendation.classify_transactions", dummy_classify)
+    recs = recommend_transactions(txs, kb_path=kb_file)
+    assert recs[0].action == "Cancel"
+    assert recs[0].info["url"] == "cancel"


### PR DESCRIPTION
## Summary
- implement recommendation engine that merges regex & LLM output
- store cancellation paths in a YAML knowledge base
- add unit tests and BDD feature tests for recommendations

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_686500769fb8832ba3ed338f72d9bcf6