### PR TITLE
Handle api_key in LLM adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ poetry run pytest
 poetry run behave
 ```
 
+## Configuration
+
+The tool loads settings from `~/.bankcleanr/config.yml`. Set your preferred LLM
+provider and API key in this file:
+
+```yaml
+llm_provider: openai
+api_key: sk-your-key
+```
+
+Run `poetry run bankcleanr config` to see which configuration file is in use.
+
 ## Running the application
 
 You can invoke the CLI through Poetry:

--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -23,9 +23,10 @@ PROVIDERS: Dict[str, Type[AbstractAdapter]] = {
 
 def get_adapter(provider: str | None = None) -> AbstractAdapter:
     """Instantiate the adapter for the configured provider."""
-    provider = provider or get_settings().llm_provider
+    settings = get_settings()
+    provider = provider or settings.llm_provider
     adapter_cls = PROVIDERS.get(provider, OpenAIAdapter)
-    return adapter_cls()
+    return adapter_cls(api_key=settings.api_key)
 
 
 def classify_transactions(transactions: Iterable, provider: str | None = None) -> List[str]:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,9 +1,11 @@
 from bankcleanr.llm import classify_transactions, PROVIDERS
 from bankcleanr.transaction import Transaction
 from bankcleanr.llm.openai import OpenAIAdapter
+from bankcleanr.settings import Settings
+from pathlib import Path
 
 class DummyAdapter(OpenAIAdapter):
-    def __init__(self, label="remote"):
+    def __init__(self, label="remote", **kwargs):
         self.label = label
 
     def classify_transactions(self, transactions):
@@ -18,3 +20,19 @@ def test_llm_fallback(monkeypatch):
     ]
     labels = classify_transactions(txs, provider="openai")
     assert labels == ["spotify", "remote"]
+
+
+def test_get_adapter_passes_api_key(monkeypatch):
+    captured = {}
+
+    class CaptureAdapter(OpenAIAdapter):
+        def __init__(self, *args, **kwargs):
+            captured["api_key"] = kwargs.get("api_key")
+
+    monkeypatch.setitem(PROVIDERS, "openai", CaptureAdapter)
+    settings = Settings(llm_provider="openai", api_key="secret", config_path=Path("cfg"))
+    monkeypatch.setattr("bankcleanr.llm.get_settings", lambda: settings)
+    from bankcleanr.llm import get_adapter
+
+    get_adapter()
+    assert captured["api_key"] == "secret"


### PR DESCRIPTION
## Summary
- wire api_key into `get_adapter`
- document api key config
- test that adapters receive the key

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68650ae7666c832bb411aecb643751a3