### PR TITLE
Mask sensitive data before LLM dispatch

### DIFF
--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Iterable, List, Dict, Type
 
 from bankcleanr.settings import get_settings
-from bankcleanr.transaction import normalise, Transaction
+from bankcleanr.transaction import normalise, Transaction, mask_transaction
 from bankcleanr.rules import heuristics
 
 from .base import AbstractAdapter
@@ -43,7 +43,8 @@ def classify_transactions(transactions: Iterable, provider: str | None = None) -
 
     if unmatched:
         adapter = get_adapter(provider)
-        llm_labels = adapter.classify_transactions(unmatched)
+        masked = [mask_transaction(tx) for tx in unmatched]
+        llm_labels = adapter.classify_transactions(masked)
         for idx, llm_label in zip(unmatched_indexes, llm_labels):
             labels[idx] = llm_label
 

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -7,3 +7,8 @@ Feature: LLM classification
       | label   |
       | spotify |
       | coffee  |
+
+  Scenario: Account details are masked before sending to the LLM
+    Given a transaction containing account details
+    When I classify the transaction with a capture adapter
+    Then the adapter received the masked transaction

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -37,3 +37,31 @@ def check_labels(context):
     assert context.labels == expected
     if hasattr(context, "original"):
         PROVIDERS["openai"] = context.original
+
+
+@given("a transaction containing account details")
+def transaction_with_account(context):
+    context.txs = [
+        Transaction(date="2024-01-01", description="Send 12-34-56 12345678", amount="-1.00")
+    ]
+
+
+@when("I classify the transaction with a capture adapter")
+def classify_with_capture(context):
+    class CaptureAdapter(OpenAIAdapter):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_transactions(self, transactions):
+            context.captured_descriptions = [tx.description for tx in transactions]
+            return ["ok"]
+
+    context.original = PROVIDERS["openai"]
+    PROVIDERS["openai"] = CaptureAdapter
+    classify_transactions(context.txs, provider="openai")
+    PROVIDERS["openai"] = context.original
+
+
+@then("the adapter received the masked transaction")
+def check_masked_tx(context):
+    assert context.captured_descriptions[0] == "Send ****3456 ****5678"

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,14 @@
+from bankcleanr.transaction import Transaction, mask_transaction, mask_account_and_sort_codes
+
+
+def test_mask_account_and_sort_codes():
+    text = "Transfer to 12-34-56 12345678"
+    assert mask_account_and_sort_codes(text) == "Transfer to ****3456 ****5678"
+
+
+def test_mask_transaction_does_not_modify_original():
+    tx = Transaction(date="2024-01-01", description="Pay 12-34-56 12345678", amount="-1.00")
+    masked = mask_transaction(tx)
+    assert masked.description == "Pay ****3456 ****5678"
+    # original untouched
+    assert tx.description == "Pay 12-34-56 12345678"


### PR DESCRIPTION
## Summary
- add helper in `transaction.py` to mask account numbers and sort codes
- mask transactions before calling any LLM adapter
- extend BDD tests for masking
- add unit tests for masking helper and LLM dispatch

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68650d47c2d4832b8f43b6da9dc5c896