### PR TITLE
Add additional LLM adapters

### DIFF
--- a/bankcleanr/llm/anthropic.py
+++ b/bankcleanr/llm/anthropic.py
@@ -1,6 +1,37 @@
+"""Adapter for Anthropic's Claude API."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
 from .base import AbstractAdapter
+from bankcleanr.transaction import normalise, Transaction
+from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 
 class AnthropicAdapter(AbstractAdapter):
-    def classify_transactions(self, transactions):
-        return ["unknown" for _ in transactions]
+    def __init__(self, model: str = "claude-3-haiku-20240307", api_key: str | None = None):
+        try:
+            import anthropic
+        except Exception:  # pragma: no cover - library may not be installed
+            self.client = None
+        else:
+            self.client = anthropic.Anthropic(api_key=api_key)
+        self.model = model
+
+    def classify_transactions(self, transactions: Iterable) -> List[str]:
+        tx_objs = [normalise(tx) for tx in transactions]
+        if self.client is None:
+            return ["unknown" for _ in tx_objs]
+
+        labels: List[str] = []
+        for tx in tx_objs:
+            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            resp = self.client.messages.create(
+                model=self.model,
+                max_tokens=5,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            content = resp.content[0].text if hasattr(resp.content[0], "text") else resp.content
+            labels.append(content.strip().lower())
+        return labels

--- a/bankcleanr/llm/local_ollama.py
+++ b/bankcleanr/llm/local_ollama.py
@@ -1,6 +1,35 @@
+"""Adapter for a locally running Ollama server."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+import requests
+
 from .base import AbstractAdapter
+from bankcleanr.transaction import normalise
+from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 
 class LocalOllamaAdapter(AbstractAdapter):
-    def classify_transactions(self, transactions):
-        return ["unknown" for _ in transactions]
+    def __init__(self, model: str = "llama3", host: str = "http://localhost:11434", api_key: str | None = None):
+        self.model = model
+        self.host = host.rstrip("/")
+        self.api_key = api_key
+
+    def classify_transactions(self, transactions: Iterable) -> List[str]:
+        tx_objs = [normalise(tx) for tx in transactions]
+        labels: List[str] = []
+        for tx in tx_objs:
+            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            try:
+                resp = requests.post(
+                    f"{self.host}/api/generate",
+                    json={"model": self.model, "prompt": prompt, "stream": False},
+                    timeout=30,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                labels.append(data.get("response", "").strip().lower())
+            except Exception:
+                labels.append("unknown")
+        return labels

--- a/bankcleanr/llm/mistral.py
+++ b/bankcleanr/llm/mistral.py
@@ -1,6 +1,36 @@
+"""Adapter for the Mistral AI chat models."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
 from .base import AbstractAdapter
+from bankcleanr.transaction import normalise
+from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 
 class MistralAdapter(AbstractAdapter):
-    def classify_transactions(self, transactions):
-        return ["unknown" for _ in transactions]
+    def __init__(self, model: str = "mistral-small", api_key: str | None = None):
+        try:
+            from mistralai.client import MistralClient
+        except Exception:  # pragma: no cover - library may not be installed
+            self.client = None
+        else:
+            self.client = MistralClient(api_key=api_key)
+        self.model = model
+
+    def classify_transactions(self, transactions: Iterable) -> List[str]:
+        tx_objs = [normalise(tx) for tx in transactions]
+        if self.client is None:
+            return ["unknown" for _ in tx_objs]
+
+        labels: List[str] = []
+        for tx in tx_objs:
+            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            resp = self.client.chat(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            message = resp.choices[0].message.content if resp.choices else ""
+            labels.append(message.strip().lower())
+        return labels

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -6,6 +6,15 @@ Feature: LLM classification
     Then the LLM labels are
       | label   |
       | spotify |
+    | coffee  |
+
+  Scenario: Fallback to Mistral adapter for unknown items
+    Given transactions requiring LLM
+    And the Mistral adapter is mocked to return "coffee"
+    When I classify transactions with the LLM
+    Then the LLM labels are
+      | label   |
+      | spotify |
       | coffee  |
 
   Scenario: Account details are masked before sending to the LLM


### PR DESCRIPTION
## Summary
- implement Mistral, Anthropic and local Ollama adapters
- add ability to mock arbitrary providers in BDD tests
- test Mistral provider
- add scenario covering Mistral provider

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68650eef63d8832b9b511195ac1e8e5e