### PR TITLE
Add new subscription heuristics

### DIFF
--- a/bankcleanr/rules/regex.py
+++ b/bankcleanr/rules/regex.py
@@ -4,6 +4,8 @@ PATTERNS = {
     "spotify": re.compile(r"spotify", re.I),
     "netflix": re.compile(r"netflix", re.I),
     "icloud": re.compile(r"icloud", re.I),
+    "amazon prime": re.compile(r"amazon\s+prime", re.I),
+    "dropbox": re.compile(r"dropbox", re.I),
 }
 
 def classify(description: str) -> str:

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -5,4 +5,6 @@ Feature: Local heuristics classification
     Then the labels are
       | label   |
       | spotify |
+      | amazon prime |
+      | dropbox |
       | unknown |

--- a/features/steps/heuristics_steps.py
+++ b/features/steps/heuristics_steps.py
@@ -7,7 +7,9 @@ from bankcleanr.rules.heuristics import classify_transactions
 def given_transactions(context):
     context.txs = [
         Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
-        Transaction(date="2024-01-02", description="Coffee", amount="-2.00"),
+        Transaction(date="2024-01-02", description="Amazon Prime membership", amount="-8.99"),
+        Transaction(date="2024-01-03", description="Dropbox yearly", amount="-119.00"),
+        Transaction(date="2024-01-04", description="Coffee", amount="-2.00"),
     ]
 
 

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -5,7 +5,9 @@ from bankcleanr.transaction import Transaction
 def test_classify_transactions():
     txs = [
         Transaction(date="2024-01-01", description="Spotify monthly", amount="-9.99"),
-        Transaction(date="2024-01-02", description="Coffee shop", amount="-2.50"),
+        Transaction(date="2024-01-02", description="Amazon Prime", amount="-8.99"),
+        Transaction(date="2024-01-03", description="Dropbox subscription", amount="-11.99"),
+        Transaction(date="2024-01-04", description="Coffee shop", amount="-2.50"),
     ]
     labels = classify_transactions(txs)
-    assert labels == ["spotify", "unknown"]
+    assert labels == ["spotify", "amazon prime", "dropbox", "unknown"]


### PR DESCRIPTION
## Summary
- tag `amazon prime` and `dropbox` subscriptions with regex heuristics
- include new transactions in heuristic examples
- test that new patterns are recognised

## Testing
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_6865267c19d0832b838c5798b2b98f48