### PR TITLE
Add PDF report support and terminal summary

### DIFF
--- a/bankcleanr/reports/writer.py
+++ b/bankcleanr/reports/writer.py
@@ -1,12 +1,120 @@
 from pathlib import Path
 import csv
-from typing import Iterable, Mapping
+from typing import Iterable, List
 from dataclasses import asdict, is_dataclass
+import yaml
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+
 from .disclaimers import GLOBAL_DISCLAIMER
 
 
-def write_summary(transactions: Iterable, output: str) -> Path:
-    """Write a minimal CSV summary including the disclaimer."""
+def _load_cancellation_data() -> List[List[str]]:
+    """Return cancellation instructions as a table."""
+    data_path = Path(__file__).resolve().parents[1] / "data" / "cancellation.yml"
+    info = yaml.safe_load(data_path.read_text())
+    rows = [["Service", "URL", "Phone", "Email"]]
+    for service, details in info.items():
+        rows.append([
+            service,
+            details.get("url", ""),
+            details.get("phone", ""),
+            details.get("email", ""),
+        ])
+    return rows
+
+
+def write_pdf_summary(transactions: Iterable, output: str) -> Path:
+    """Write a PDF summary with transactions and cancellation info."""
+    path = Path(output)
+    doc = SimpleDocTemplate(str(path), pagesize=letter)
+    styles = getSampleStyleSheet()
+
+    tx_rows: List[List[str]] = [["date", "description", "amount", "balance"]]
+    for tx in transactions:
+        if is_dataclass(tx):
+            tx = asdict(tx)
+        tx_rows.append([
+            tx.get("date", ""),
+            tx.get("description", ""),
+            tx.get("amount", ""),
+            tx.get("balance", ""),
+        ])
+
+    elements = [Paragraph("Transactions", styles["Heading2"])]
+    table = Table(tx_rows)
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    elements.append(table)
+    elements.append(Spacer(1, 0.5 * inch))
+
+    # Cancellation appendix
+    elements.append(Paragraph("How to cancel", styles["Heading2"]))
+    cancel_table = Table(_load_cancellation_data())
+    cancel_table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+            ]
+        )
+    )
+    elements.append(cancel_table)
+
+    elements.append(Spacer(1, 0.5 * inch))
+    elements.append(Paragraph(GLOBAL_DISCLAIMER, styles["Normal"]))
+
+    doc.build(elements)
+    return path
+
+
+def format_terminal_summary(transactions: Iterable) -> str:
+    """Return a formatted text summary suitable for terminal output."""
+    lines: List[str] = ["date | description | amount | balance"]
+    for tx in transactions:
+        if is_dataclass(tx):
+            tx = asdict(tx)
+        line = " | ".join(
+            [
+                str(tx.get("date", "")),
+                str(tx.get("description", "")),
+                str(tx.get("amount", "")),
+                str(tx.get("balance", "")),
+            ]
+        )
+        lines.append(line)
+
+    lines.append("")
+    lines.append("How to cancel:")
+    for row in _load_cancellation_data()[1:]:
+        service, url, phone, email = row
+        info = ", ".join(filter(None, [url, phone, email]))
+        lines.append(f"- {service}: {info}")
+
+    lines.append("")
+    lines.append(GLOBAL_DISCLAIMER)
+    return "\n".join(lines)
+
+
+def write_summary(transactions: Iterable, output: str):
+    """Write a summary in CSV or PDF format or return terminal text."""
+    if output == "terminal":
+        return format_terminal_summary(transactions)
+
+    ext = Path(output).suffix.lower()
+    if ext == ".pdf":
+        return write_pdf_summary(transactions, output)
+
+    # default to CSV
     path = Path(output)
     with path.open("w", newline="") as f:
         writer = csv.writer(f)

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -8,3 +8,9 @@ Feature: Command-line interface
     Then the exit code is 0
     And the summary file exists
     And the summary contains the disclaimer
+
+  Scenario: Analyse a PDF statement to PDF output
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" to "summary.pdf"
+    Then the exit code is 0
+    And the summary file exists
+    And the PDF summary contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -1,7 +1,11 @@
 from behave import when, then
 import subprocess
 from pathlib import Path
+import re
+from behave import use_step_matcher
 from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
+
+use_step_matcher("re")
 
 @when('I run the bankcleanr config command')
 def run_config(context):
@@ -12,14 +16,15 @@ def check_exit(context):
     assert context.result.returncode == 0
 
 
-@when('I run the bankcleanr analyse command with "{pdf}"')
-def run_analyse(context, pdf):
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^\"]+)"(?: to "(?P<outfile>[^\"]+)")?')
+def run_analyse(context, pdf, outfile=None):
     root = Path(__file__).resolve().parents[2]
-    context.summary_path = root / "summary.csv"
+    context.summary_path = root / (outfile or "summary.csv")
     if context.summary_path.exists():
         context.summary_path.unlink()
     context.result = subprocess.run(
-        ["python", "-m", "bankcleanr", "analyse", str(root / pdf)],
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf)]
+        + (["--output", outfile] if outfile else []),
         capture_output=True,
         cwd=root,
     )
@@ -34,3 +39,11 @@ def summary_exists(context):
 def summary_contains_disclaimer(context):
     text = context.summary_path.read_text()
     assert GLOBAL_DISCLAIMER in text
+
+
+@then('the PDF summary contains the disclaimer')
+def pdf_summary_contains_disclaimer(context):
+    import pdfplumber
+    with pdfplumber.open(context.summary_path) as pdf:
+        content = "".join(page.extract_text() or "" for page in pdf.pages)
+    assert GLOBAL_DISCLAIMER.replace("\n", " ") in content.replace("\n", " ")


### PR DESCRIPTION
## Summary
- support PDF and terminal summaries in `writer`
- add cancellation appendix and disclaimer handling
- test new report functions
- expand CLI feature test for PDF output

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6865421bf8c4832bb56ea41181d205e5