### PR TITLE
Add pdf and terminal options

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -2,7 +2,11 @@ import typer
 from pathlib import Path
 
 from .io.loader import load_transactions
-from .reports.writer import write_summary
+from .reports.writer import (
+    write_summary,
+    write_pdf_summary,
+    format_terminal_summary,
+)
 from .settings import get_settings
 
 app = typer.Typer(help="BankCleanr CLI")
@@ -19,11 +23,21 @@ SAMPLE_STATEMENT = (
 def analyse(
     file: str = typer.Argument(str(SAMPLE_STATEMENT)),
     output: str = "summary.csv",
+    pdf: str | None = typer.Option(
+        None, "--pdf", help="Write an additional PDF summary to this file"
+    ),
+    terminal: bool = typer.Option(
+        False, "--terminal", help="Display the summary in the terminal"
+    ),
 ):
     """Analyse a statement file and write a summary."""
     typer.echo(f"Analysing {file}")
     transactions = load_transactions(file)
     write_summary(transactions, output)
+    if pdf:
+        write_pdf_summary(transactions, pdf)
+    if terminal:
+        typer.echo(format_terminal_summary(transactions))
     typer.echo("Analysis complete")
 
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -14,3 +14,14 @@ Feature: Command-line interface
     Then the exit code is 0
     And the summary file exists
     And the PDF summary contains the disclaimer
+
+  Scenario: Analyse a PDF statement with the pdf option
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with pdf "extra.pdf"
+    Then the exit code is 0
+    And the summary file exists
+    And the PDF summary contains the disclaimer
+
+  Scenario: Show terminal output
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
+    Then the exit code is 0
+    And the terminal output contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -30,6 +30,29 @@ def run_analyse(context, pdf, outfile=None):
     )
 
 
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with pdf "(?P<pdfout>[^"]+)"')
+def run_analyse_pdf_option(context, pdf, pdfout):
+    root = Path(__file__).resolve().parents[2]
+    context.summary_path = root / pdfout
+    if context.summary_path.exists():
+        context.summary_path.unlink()
+    context.result = subprocess.run(
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf), "--pdf", pdfout],
+        capture_output=True,
+        cwd=root,
+    )
+
+
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with terminal output')
+def run_analyse_terminal_option(context, pdf):
+    root = Path(__file__).resolve().parents[2]
+    context.result = subprocess.run(
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf), "--terminal"],
+        capture_output=True,
+        cwd=root,
+    )
+
+
 @then('the summary file exists')
 def summary_exists(context):
     assert context.summary_path.exists()
@@ -47,3 +70,9 @@ def pdf_summary_contains_disclaimer(context):
     with pdfplumber.open(context.summary_path) as pdf:
         content = "".join(page.extract_text() or "" for page in pdf.pages)
     assert GLOBAL_DISCLAIMER.replace("\n", " ") in content.replace("\n", " ")
+
+
+@then('the terminal output contains the disclaimer')
+def terminal_output_contains_disclaimer(context):
+    output = context.result.stdout.decode()
+    assert GLOBAL_DISCLAIMER in output


### PR DESCRIPTION
## Summary
- extend CLI analyse command with `--pdf` and `--terminal` options
- update command line feature tests for the new flags
- implement Behave steps for pdf and terminal options

## Testing
- `pip install -e .[dev]` *(fails: bankcleanr 0.1.0 does not provide the extra 'dev')*
- `pip install reportlab`
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6865517ec4c4832b8ed2f401de43b7db