### PR TITLE
Add cancellation details to reports

### DIFF
--- a/bankcleanr/recommendation.py
+++ b/bankcleanr/recommendation.py
@@ -43,7 +43,12 @@ def recommend_transactions(
     for tx, label in zip(txs, labels):
         if label in kb:
             action = "Cancel"
-            info = kb[label]
+            details = kb[label]
+            info = {
+                k: v
+                for k, v in details.items()
+                if k in {"url", "email", "phone"} and v
+            }
         elif label == "unknown":
             action = "Investigate"
             info = None

--- a/tests/test_io_writer.py
+++ b/tests/test_io_writer.py
@@ -37,9 +37,19 @@ def test_write_summary(tmp_path):
     with output.open() as f:
         rows = list(csv.reader(f))
 
-    assert rows[0] == ["date", "description", "amount", "balance"]
-    assert rows[1] == ["2023-01-01", "Coffee", "-1.00", "99.00"]
-    assert rows[2] == ["2023-01-02", "Tea", "-2.00", "97.00"]
+    assert rows[0] == [
+        "date",
+        "description",
+        "amount",
+        "balance",
+        "category",
+        "action",
+        "url",
+        "email",
+        "phone",
+    ]
+    assert rows[1] == ["2023-01-01", "Coffee", "-1.00", "99.00", "", "", "", "", ""]
+    assert rows[2] == ["2023-01-02", "Tea", "-2.00", "97.00", "", "", "", "", ""]
     assert rows[3] == []
     assert rows[4] == [GLOBAL_DISCLAIMER]
 
@@ -65,4 +75,5 @@ def test_format_terminal_summary():
     ]
     text = format_terminal_summary(transactions)
     assert "Coffee" in text
+    assert "category" in text.splitlines()[0]
     assert GLOBAL_DISCLAIMER in text

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -12,7 +12,13 @@ def test_load_knowledge_base(tmp_path):
 
 
 def test_recommend_transactions(monkeypatch, tmp_path):
-    kb = {"spotify": {"url": "cancel"}}
+    kb = {
+        "spotify": {
+            "url": "cancel-url",
+            "email": "cancel@example.com",
+            "phone": "123",
+        }
+    }
     kb_file = tmp_path / "kb.yml"
     kb_file.write_text(yaml.safe_dump(kb))
 
@@ -25,4 +31,6 @@ def test_recommend_transactions(monkeypatch, tmp_path):
     recs = recommend_transactions(txs, kb_path=kb_file)
     assert recs[0].category == "spotify"
     assert recs[0].action == "Cancel"
-    assert recs[0].info["url"] == "cancel"
+    assert recs[0].info["url"] == "cancel-url"
+    assert recs[0].info["email"] == "cancel@example.com"
+    assert recs[0].info["phone"] == "123"


### PR DESCRIPTION
## Summary
- ensure `recommend_transactions` returns `url`, `email` and `phone` info
- display cancellation details in CSV, PDF and terminal summaries
- adjust unit tests for new output columns

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_686554f4ce84832ba8c1635166acbf6f