### PR TITLE
Add summary output tests

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -25,3 +25,10 @@ Feature: Command-line interface
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
     Then the exit code is 0
     And the terminal output contains the disclaimer
+
+  Scenario: Analyse a PDF statement to PDF output with terminal output
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" to "combo.pdf" with terminal output
+    Then the exit code is 0
+    And the summary file exists
+    And the terminal output contains the disclaimer
+    And the PDF summary contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -53,6 +53,29 @@ def run_analyse_terminal_option(context, pdf):
     )
 
 
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" to "(?P<outfile>[^"]+)" with terminal output')
+def run_analyse_output_terminal(context, pdf, outfile):
+    """Run analyse writing to a file and showing terminal output."""
+    root = Path(__file__).resolve().parents[2]
+    context.summary_path = root / outfile
+    if context.summary_path.exists():
+        context.summary_path.unlink()
+    context.result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "bankcleanr",
+            "analyse",
+            str(root / pdf),
+            "--output",
+            outfile,
+            "--terminal",
+        ],
+        capture_output=True,
+        cwd=root,
+    )
+
+
 @then('the summary file exists')
 def summary_exists(context):
     assert context.summary_path.exists()

--- a/tests/test_io_writer.py
+++ b/tests/test_io_writer.py
@@ -3,7 +3,11 @@ import pytest
 import pdfplumber
 
 from bankcleanr.io.loader import load_transactions
-from bankcleanr.reports.writer import write_summary, write_pdf_summary, format_terminal_summary
+from bankcleanr.reports.writer import (
+    write_summary,
+    write_pdf_summary,
+    format_terminal_summary,
+)
 from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
 
 
@@ -76,4 +80,24 @@ def test_format_terminal_summary():
     text = format_terminal_summary(transactions)
     assert "Coffee" in text
     assert "category" in text.splitlines()[0]
+    assert GLOBAL_DISCLAIMER in text
+
+
+def test_write_summary_pdf(tmp_path):
+    transactions = [{"date": "2023-01-01", "description": "Coffee", "amount": "-1.00", "balance": "99.00"}]
+    output = tmp_path / "out.pdf"
+    path = write_summary(transactions, str(output))
+    assert path == output
+
+    with pdfplumber.open(output) as pdf:
+        text = "".join(page.extract_text() or "" for page in pdf.pages)
+
+    assert "Coffee" in text
+    assert GLOBAL_DISCLAIMER.replace("\n", " ") in text.replace("\n", " ")
+
+
+def test_write_summary_terminal():
+    transactions = [{"date": "2023-01-01", "description": "Coffee", "amount": "-1.00", "balance": "99.00"}]
+    text = write_summary(transactions, "terminal")
+    assert "Coffee" in text
     assert GLOBAL_DISCLAIMER in text


### PR DESCRIPTION
## Summary
- test PDF and terminal output generation in writer
- check CLI can output PDF while showing terminal results

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_686557830128832ba5d128b2a2649507