### PR TITLE
Add manual verification reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ poetry run bankcleanr analyse path/to/statement.pdf
 ```
 
 The `analyse` command writes a `summary.csv` to the working directory.
+It also prints a reminder to verify each recommendation manually.
+
+## Disclaimer
+
+Every summary includes the following disclaimer:
+
+```
+This tool automates the categorisation of your personal bank transactions.
+It is not regulated financial advice. Results may be incomplete or inaccurate.
+All processing occurs on this computer; only transaction descriptions are sent to the language-model provider you choose.
+Use at your own risk. Always verify recommendations with the original supplier or your bank before cancelling any service.
+```
+
+Always read this disclaimer in your output and verify each recommendation yourself before taking any action.

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -8,6 +8,7 @@ from .reports.writer import (
     format_terminal_summary,
 )
 from .settings import get_settings
+from .reports.disclaimers import GLOBAL_DISCLAIMER
 
 app = typer.Typer(help="BankCleanr CLI")
 
@@ -39,6 +40,7 @@ def analyse(
     if terminal:
         typer.echo(format_terminal_summary(transactions))
     typer.echo("Analysis complete")
+    typer.echo(GLOBAL_DISCLAIMER)
 
 
 @app.command()

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -8,6 +8,7 @@ Feature: Command-line interface
     Then the exit code is 0
     And the summary file exists
     And the summary contains the disclaimer
+    And the terminal output contains the disclaimer
 
   Scenario: Analyse a PDF statement to PDF output
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" to "summary.pdf"


### PR DESCRIPTION
## Summary
- update README with disclaimer text
- print disclaimer after running `analyse`
- expect disclaimer text in default CLI output

## Testing
- `poetry run pytest -q`
- `poetry run behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6865704d9258832b9317cfb2bba5807e