### PR TITLE
Add directory support to CLI analyse command

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -1,7 +1,7 @@
 import typer
 from pathlib import Path
 
-from .io.loader import load_transactions
+from .io.loader import load_from_path
 from .reports.writer import (
     write_summary,
     write_pdf_summary,
@@ -22,7 +22,10 @@ SAMPLE_STATEMENT = (
 
 @app.command()
 def analyse(
-    file: str = typer.Argument(str(SAMPLE_STATEMENT)),
+    path: str = typer.Argument(
+        str(SAMPLE_STATEMENT),
+        help="Path to a PDF file or directory containing PDF files",
+    ),
     output: str = "summary.csv",
     pdf: str | None = typer.Option(
         None, "--pdf", help="Write an additional PDF summary to this file"
@@ -31,9 +34,9 @@ def analyse(
         False, "--terminal", help="Display the summary in the terminal"
     ),
 ):
-    """Analyse a statement file and write a summary."""
-    typer.echo(f"Analysing {file}")
-    transactions = load_transactions(file)
+    """Analyse a statement file or directory and write a summary."""
+    typer.echo(f"Analysing {path}")
+    transactions = load_from_path(path)
     write_summary(transactions, output)
     if pdf:
         write_pdf_summary(transactions, pdf)

--- a/bankcleanr/io/loader.py
+++ b/bankcleanr/io/loader.py
@@ -1,4 +1,5 @@
 from typing import List, Mapping
+from pathlib import Path
 from .pdf import generic
 
 
@@ -7,3 +8,14 @@ def load_transactions(path: str) -> List[Mapping]:
     if path.lower().endswith(".pdf"):
         return generic.parse_pdf(path)
     raise ValueError("Unsupported file type")
+
+
+def load_from_path(path: str) -> List[Mapping]:
+    """Load transactions from a file or directory of PDF files."""
+    p = Path(path)
+    if p.is_dir():
+        transactions: List[Mapping] = []
+        for pdf in sorted(p.glob("*.pdf")):
+            transactions.extend(load_transactions(str(pdf)))
+        return transactions
+    return load_transactions(str(p))

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -33,3 +33,10 @@ Feature: Command-line interface
     And the summary file exists
     And the terminal output contains the disclaimer
     And the PDF summary contains the disclaimer
+
+  Scenario: Analyse a directory of PDF statements
+    When I run the bankcleanr analyse command with "Redacted bank statements"
+    Then the exit code is 0
+    And the summary file exists
+    And the summary contains the disclaimer
+    And the terminal output contains the disclaimer

--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from bankcleanr.io import loader
+
+
+def test_load_from_path_file(monkeypatch, tmp_path):
+    called = []
+
+    def fake_load(path):
+        called.append(path)
+        return ["tx"]
+
+    monkeypatch.setattr(loader, "load_transactions", fake_load)
+    pdf = tmp_path / "file.pdf"
+    pdf.write_text("dummy")
+
+    result = loader.load_from_path(str(pdf))
+    assert result == ["tx"]
+    assert called == [str(pdf)]
+
+
+def test_load_from_path_directory(monkeypatch, tmp_path):
+    order = []
+
+    def fake_load(path):
+        order.append(Path(path).name)
+        return [path]
+
+    monkeypatch.setattr(loader, "load_transactions", fake_load)
+
+    (tmp_path / "b.pdf").write_text("b")
+    (tmp_path / "a.pdf").write_text("a")
+
+    result = loader.load_from_path(str(tmp_path))
+    assert order == ["a.pdf", "b.pdf"]
+    assert result == [str(tmp_path / "a.pdf"), str(tmp_path / "b.pdf")]


### PR DESCRIPTION
## Summary
- allow `bankcleanr analyse` to accept a directory
- load and aggregate transactions from all PDFs in a directory
- add helper `load_from_path` to load files or directories
- extend CLI BDD tests for directory usage
- unit tests for new loader helper

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ccaa03a8832b8fd418c2b3efb6d3