### PR TITLE
Add PDF ignore rules and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 summary.csv
+
+# Ignore PDF statements
+*.pdf
+!Redacted bank statements/*.pdf

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Use at your own risk. Always verify recommendations with the original supplier o
 ```
 
 Always read this disclaimer in your output and verify each recommendation yourself before taking any action.
+
+## Version control
+
+Personal PDF statements should not be committed to the repository. The `.gitignore` file ignores `*.pdf` files while allowing the sample files kept in `Redacted bank statements`.


### PR DESCRIPTION
## Summary
- prevent accidental checkin of personal statements in `.gitignore`
- mention that personal PDF statements should not be committed

## Testing
- `pytest -q` *(fails: No module named 'pdfplumber')*
- `behave features/cli.feature` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683cc33834832bbb48f77d42bee427