### PR TITLE
Add live LLM tests

### DIFF
--- a/features/llm_live.feature
+++ b/features/llm_live.feature
@@ -1,0 +1,15 @@
+Feature: Live LLM classification
+  Scenario: Classify a transaction with OpenAI
+    Given a sample transaction "Coffee shop"
+    When I classify the transaction with the live "openai" adapter
+    Then the returned category is not "unknown"
+
+  Scenario: Classify a transaction with BFL
+    Given a sample transaction "Coffee shop"
+    When I classify the transaction with the live "bfl" adapter
+    Then the returned category is not "unknown"
+
+  Scenario: Classify a transaction with Gemini
+    Given a sample transaction "Coffee shop"
+    When I classify the transaction with the live "gemini" adapter
+    Then the returned category is not "unknown"


### PR DESCRIPTION
## Summary
- add a new optional feature file for live LLM API checks
- allow llm steps to run real adapters using environment keys

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_686842e2f584832b9427ce836703b065