### PR TITLE
Update README config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,15 @@ poetry run behave
 ## Configuration
 
 The tool loads settings from `~/.bankcleanr/config.yml`. Set your preferred LLM
-provider in this file. API keys are taken from environment variables so you
-never need to store them on disk:
+provider in this file:
 
 ```yaml
+# ~/.bankcleanr/config.yml
 llm_provider: openai
-
-# API keys
-OPENAI_API_KEY=sk-your-openai-key
-GEMINI_API_KEY=your-gemini-key
 ```
+
+API keys are supplied via environment variables such as `OPENAI_API_KEY` or
+`GEMINI_API_KEY`.
 
 Run `poetry run bankcleanr config` to see which configuration file is in use.
 


### PR DESCRIPTION
## Summary
- clarify how to configure the LLM provider
- show `~/.bankcleanr/config.yml` snippet
- document that API keys come from environment variables

## Testing
- `poetry run pytest`
- `OPENAI_API_KEY=dummy GEMINI_API_KEY=dummy BFL_API_KEY=dummy poetry run behave` *(fails: SSL_ERROR_SSL self-signed cert)*

------
https://chatgpt.com/codex/tasks/task_e_686924543d2c832b836249aa2000af5d