### PR TITLE
Implement BFL API key fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ provider in this file:
 llm_provider: openai
 ```
 
-API keys are supplied via environment variables such as `OPENAI_API_KEY` or
-`GEMINI_API_KEY`.
+API keys are supplied via environment variables. Use `OPENAI_API_KEY` for the
+OpenAI adapter or `GEMINI_API_KEY` for Gemini. The BFL adapter checks
+`BFL_API_KEY` and falls back to `OPENAI_API_KEY` if the former is not set.
 
 Run `poetry run bankcleanr config` to see which configuration file is in use.
 

--- a/bankcleanr/settings.py
+++ b/bankcleanr/settings.py
@@ -22,10 +22,15 @@ def load_settings(path: Path = CONFIG_PATH) -> Settings:
         "gemini": "GEMINI_API_KEY",
         "mistral": "MISTRAL_API_KEY",
         "anthropic": "ANTHROPIC_API_KEY",
+        "bfl": "BFL_API_KEY",
     }
-    env_var = env_map.get(settings.llm_provider.lower())
+    provider = settings.llm_provider.lower()
+    env_var = env_map.get(provider)
     if env_var and os.getenv(env_var):
         settings.api_key = os.getenv(env_var)
+    elif provider == "bfl" and os.getenv("OPENAI_API_KEY"):
+        # Fall back to OpenAI credentials when BFL key is missing
+        settings.api_key = os.getenv("OPENAI_API_KEY")
     return settings
 
 


### PR DESCRIPTION
## Summary
- support BFL_API_KEY in `load_settings` and fall back to OPENAI_API_KEY
- document BFL key usage in Configuration docs
- test that get_adapter for BFL reads from environment variables

## Testing
- `pytest -q`
- `behave -q` *(fails: Show config path, Analyse PDF scenarios, Live adapter scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_686996e6d7d0832b94a682093da1a5db