### PR TITLE
Add savings calculation and type totals

### DIFF
--- a/bankcleanr/analytics.py
+++ b/bankcleanr/analytics.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Iterable, Dict
+
+from .recommendation import Recommendation
+
+# Map transaction categories to high level types
+CATEGORY_TYPES = {
+    "spotify": "entertainment",
+    "netflix": "entertainment",
+    "amazon prime": "entertainment",
+    "icloud": "cloud",
+    "dropbox": "cloud",
+}
+
+
+def _parse_amount(amount: str) -> Decimal:
+    """Return Decimal value from transaction amount string."""
+    try:
+        return Decimal(amount)
+    except Exception:
+        return Decimal("0")
+
+
+def _get_attr(obj, name, default=""):
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def calculate_savings(recommendations: Iterable[Recommendation]) -> Decimal:
+    """Return total potential savings for recommendations marked Cancel."""
+    total = Decimal("0")
+    for rec in recommendations:
+        action = _get_attr(rec, "action").lower()
+        if action == "cancel":
+            if isinstance(rec, Recommendation):
+                amt_str = rec.transaction.amount
+            else:
+                amt_str = _get_attr(rec, "amount", "0")
+            amt = _parse_amount(amt_str)
+            total += abs(amt)
+    return total
+
+
+def totals_by_type(recommendations: Iterable[Recommendation]) -> Dict[str, Decimal]:
+    """Group transactions by high level type and total their amounts."""
+    totals: Dict[str, Decimal] = {}
+    for rec in recommendations:
+        category = _get_attr(rec, "category", "other").lower()
+        group = CATEGORY_TYPES.get(category, "other")
+        if isinstance(rec, Recommendation):
+            amt_str = rec.transaction.amount
+        else:
+            amt_str = _get_attr(rec, "amount", "0")
+        amt = _parse_amount(amt_str)
+        totals[group] = totals.get(group, Decimal("0")) + abs(amt)
+    return totals

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -7,6 +7,9 @@ from .reports.writer import (
     write_pdf_summary,
     format_terminal_summary,
 )
+from .recommendation import Recommendation, load_knowledge_base
+from .rules import heuristics
+from .analytics import calculate_savings, totals_by_type
 from .settings import get_settings
 from .reports.disclaimers import GLOBAL_DISCLAIMER
 
@@ -37,11 +40,33 @@ def analyse(
     """Analyse a statement file or directory and write a summary."""
     typer.echo(f"Analysing {path}")
     transactions = load_from_path(path)
-    write_summary(transactions, output)
+
+    # build simple recommendations using heuristics only
+    labels = heuristics.classify_transactions(transactions)
+    kb = load_knowledge_base()
+    recs: list[Recommendation] = []
+    for tx, label in zip(transactions, labels):
+        if label in kb:
+            action = "Cancel"
+            info = kb[label]
+        else:
+            action = "Keep"
+            info = None
+        recs.append(Recommendation(tx, label, action, info))
+
+    write_summary(recs, output)
     if pdf:
-        write_pdf_summary(transactions, pdf)
+        write_pdf_summary(recs, pdf)
     if terminal:
-        typer.echo(format_terminal_summary(transactions))
+        typer.echo(format_terminal_summary(recs))
+
+    savings = calculate_savings(recs)
+    totals = totals_by_type(recs)
+    typer.echo(f"Potential savings if cancelled: {savings:.2f}")
+    if totals:
+        typer.echo("Totals by type:")
+        for name, total in totals.items():
+            typer.echo(f"- {name}: {total:.2f}")
     typer.echo("Analysis complete")
     typer.echo(GLOBAL_DISCLAIMER)
 

--- a/bankcleanr/reports/writer.py
+++ b/bankcleanr/reports/writer.py
@@ -3,6 +3,8 @@ import csv
 from typing import Iterable, List
 from dataclasses import asdict, is_dataclass
 import yaml
+
+from bankcleanr.analytics import calculate_savings, totals_by_type
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
@@ -137,6 +139,18 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
     )
     elements.append(cancel_table)
 
+    # Summary figures
+    savings = calculate_savings(transactions)
+    totals = totals_by_type(transactions)
+    elements.append(Spacer(1, 0.25 * inch))
+    elements.append(
+        Paragraph(f"Potential savings if cancelled: {savings:.2f}", styles["Normal"])
+    )
+    if totals:
+        elements.append(Paragraph("Totals by type:", styles["Heading3"]))
+        for name, total in totals.items():
+            elements.append(Paragraph(f"- {name}: {total:.2f}", styles["Normal"]))
+
     elements.append(Spacer(1, 0.5 * inch))
     elements.append(Paragraph(GLOBAL_DISCLAIMER, styles["Normal"]))
 
@@ -179,6 +193,16 @@ def format_terminal_summary(transactions: Iterable, categories: Iterable[str] | 
         service, url, phone, email = row
         info = ", ".join(filter(None, [url, phone, email]))
         lines.append(f"- {service}: {info}")
+
+    savings = calculate_savings(transactions)
+    totals = totals_by_type(transactions)
+
+    lines.append("")
+    lines.append(f"Potential savings if cancelled: {savings:.2f}")
+    if totals:
+        lines.append("Totals by type:")
+        for name, total in totals.items():
+            lines.append(f"- {name}: {total:.2f}")
 
     lines.append("")
     lines.append(GLOBAL_DISCLAIMER)

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -27,6 +27,11 @@ Feature: Command-line interface
     Then the exit code is 0
     And the terminal output contains the disclaimer
 
+  Scenario: Show savings summary in terminal output
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
+    Then the exit code is 0
+    And the terminal output shows savings
+
   Scenario: Analyse a PDF statement to PDF output with terminal output
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" to "combo.pdf" with terminal output
     Then the exit code is 0

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -99,3 +99,9 @@ def pdf_summary_contains_disclaimer(context):
 def terminal_output_contains_disclaimer(context):
     output = context.result.stdout.decode()
     assert GLOBAL_DISCLAIMER in output
+
+
+@then('the terminal output shows savings')
+def terminal_output_shows_savings(context):
+    output = context.result.stdout.decode().lower()
+    assert "potential savings" in output

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+from bankcleanr.transaction import Transaction
+from bankcleanr.recommendation import Recommendation
+from bankcleanr.analytics import calculate_savings, totals_by_type
+
+
+def test_calculate_savings():
+    recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Spotify", amount="-9.99"), "spotify", "Cancel"),
+        Recommendation(Transaction(date="2024-01-02", description="Coffee", amount="-2.00"), "coffee", "Keep"),
+    ]
+    assert calculate_savings(recs) == Decimal("9.99")
+
+
+def test_totals_by_type():
+    recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Spotify", amount="-9.99"), "spotify", "Cancel"),
+        Recommendation(Transaction(date="2024-01-02", description="Dropbox", amount="-5.00"), "dropbox", "Cancel"),
+        Recommendation(Transaction(date="2024-01-03", description="Bus", amount="-2.50"), "bus", "Keep"),
+    ]
+    totals = totals_by_type(recs)
+    assert totals["entertainment"] == Decimal("9.99")
+    assert totals["cloud"] == Decimal("5.00")
+    assert totals["other"] == Decimal("2.50")


### PR DESCRIPTION
## Summary
- implement `calculate_savings` and `totals_by_type` in new analytics module
- include potential savings and grouped totals in PDF/terminal summaries
- show savings figures from CLI using heuristics-based recommendations
- extend CLI BDD test to check new output
- add unit tests for analytics helpers

## Testing
- `pytest -q`
- `behave -q` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_686ac3f6b7a8832b90c0cbe6372b5b8b