### PR TITLE
Fix disclaimer output for terminal mode

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -68,7 +68,8 @@ def analyse(
         for name, total in totals.items():
             typer.echo(f"- {name}: {total:.2f}")
     typer.echo("Analysis complete")
-    typer.echo(GLOBAL_DISCLAIMER)
+    if not terminal:
+        typer.echo(GLOBAL_DISCLAIMER)
 
 
 @app.command()

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -25,7 +25,7 @@ Feature: Command-line interface
   Scenario: Show terminal output
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
     Then the exit code is 0
-    And the terminal output contains the disclaimer
+    And the terminal output contains the disclaimer once
 
   Scenario: Show savings summary in terminal output
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
@@ -36,7 +36,7 @@ Feature: Command-line interface
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" to "combo.pdf" with terminal output
     Then the exit code is 0
     And the summary file exists
-    And the terminal output contains the disclaimer
+    And the terminal output contains the disclaimer once
     And the PDF summary contains the disclaimer
 
   Scenario: Analyse a directory of PDF statements

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -101,6 +101,13 @@ def terminal_output_contains_disclaimer(context):
     assert GLOBAL_DISCLAIMER in output
 
 
+@then('the terminal output contains the disclaimer once')
+def terminal_output_contains_disclaimer_once(context):
+    """Ensure the disclaimer appears exactly once in terminal output."""
+    output = context.result.stdout.decode()
+    assert output.count(GLOBAL_DISCLAIMER) == 1
+
+
 @then('the terminal output shows savings')
 def terminal_output_shows_savings(context):
     output = context.result.stdout.decode().lower()


### PR DESCRIPTION
## Summary
- avoid duplicate disclaimer when using `--terminal`
- check for a single disclaimer in CLI features

## Testing
- `pytest -q`
- `behave -q` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_686acb909c80832b8c18eee7e4266afa