### PR TITLE
Check client availability for live adapters

### DIFF
--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -150,6 +150,10 @@ def classify_live(context, provider):
         return
     adapter_cls = PROVIDERS[provider]
     adapter = adapter_cls(api_key=api_key)
+    client = getattr(adapter, "client", getattr(adapter, "delegate", None))
+    if client is None:
+        context.scenario.skip("provider not available")
+        return
     context.labels = adapter.classify_transactions(context.txs)
 
 

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,21 @@
+import builtins
+import sys
+from bankcleanr.llm.gemini import GeminiAdapter
+from bankcleanr.transaction import Transaction
+
+
+def test_returns_unknown_when_library_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "google.generativeai":
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("google.generativeai", None)
+
+    adapter = GeminiAdapter(api_key="dummy")
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    labels = adapter.classify_transactions([tx])
+    assert labels == ["unknown"]


### PR DESCRIPTION
## Summary
- skip live classification scenarios if provider client is unavailable
- test Gemini adapter fallback when google library is missing

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_687232405888832ba993e704127747b7