### PR TITLE
Add CLI directory PDF summary scenario

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -2,6 +2,7 @@ import typer
 from pathlib import Path
 
 from .io.loader import load_from_path
+from typing import Optional
 from .reports.writer import (
     write_summary,
     write_pdf_summary,
@@ -30,7 +31,7 @@ def analyse(
         help="Path to a PDF file or directory containing PDF files",
     ),
     output: str = "summary.csv",
-    pdf: str | None = typer.Option(
+    pdf: Optional[str] = typer.Option(
         None, "--pdf", help="Write an additional PDF summary to this file"
     ),
     terminal: bool = typer.Option(

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -45,3 +45,9 @@ Feature: Command-line interface
     And the summary file exists
     And the summary contains the disclaimer
     And the terminal output contains the disclaimer
+
+  Scenario: Analyse a directory of PDF statements to PDF output
+    When I run the bankcleanr analyse command with "Redacted bank statements" with pdf "dir_summary.pdf"
+    Then the exit code is 0
+    And the summary file exists
+    And the PDF summary contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -43,6 +43,12 @@ def run_analyse_pdf_option(context, pdf, pdfout):
     )
 
 
+@when(r'I run the bankcleanr analyse command on directory "(?P<dir>[^"]+)" with pdf "(?P<pdfout>[^"]+)"')
+def run_analyse_directory_pdf_option(context, dir, pdfout):
+    """Analyse a directory of statements writing the results to a PDF."""
+    run_analyse_pdf_option(context, dir, pdfout)
+
+
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with terminal output')
 def run_analyse_terminal_option(context, pdf):
     root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- add scenario for analysing a directory with `--pdf`
- support Optional typing for pdf option
- add step to handle directory `--pdf` runs

## Testing
- `pytest -q`
- `behave`

------
https://chatgpt.com/codex/tasks/task_e_687233f9e254832b999e29eb7deee241