### PR TITLE
Add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ poetry run bankcleanr config
 poetry run bankcleanr analyse path/to/statement.pdf
 # or analyse every PDF in a directory
 poetry run bankcleanr analyse "Redacted bank statements"
+# write results to a separate directory
+poetry run bankcleanr analyse path/to/statement.pdf --outdir results/run1
 
 ```
+Using `--outdir` keeps your work organised. Test runs can write to something
+like `results/tests` while real analyses store their summaries in another
+folder.
 
 The second form accepts a folder path and processes each PDF it finds. The
 combined results are written to `summary.csv` in the current directory.

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -34,6 +34,11 @@ def analyse(
     pdf: Optional[str] = typer.Option(
         None, "--pdf", help="Write an additional PDF summary to this file"
     ),
+    outdir: Optional[str] = typer.Option(
+        None,
+        "--outdir",
+        help="Directory to write summary.csv and PDF outputs",
+    ),
     terminal: bool = typer.Option(
         False, "--terminal", help="Display the summary in the terminal"
     ),
@@ -55,9 +60,21 @@ def analyse(
             info = None
         recs.append(Recommendation(tx, label, action, info))
 
-    write_summary(recs, output)
+    outdir_path: Path | None = None
+    if outdir:
+        outdir_path = Path(outdir)
+        outdir_path.mkdir(parents=True, exist_ok=True)
+
+    output_path = Path(output)
+    if outdir_path:
+        output_path = outdir_path / output_path.name
+    write_summary(recs, str(output_path))
+
     if pdf:
-        write_pdf_summary(recs, pdf)
+        pdf_path = Path(pdf)
+        if outdir_path:
+            pdf_path = outdir_path / pdf_path.name
+        write_pdf_summary(recs, str(pdf_path))
     if terminal:
         typer.echo(format_terminal_summary(recs))
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -51,3 +51,9 @@ Feature: Command-line interface
     Then the exit code is 0
     And the summary file exists
     And the PDF summary contains the disclaimer
+
+  Scenario: Analyse a PDF statement with the outdir option
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" in outdir "results"
+    Then the exit code is 0
+    And the summary file exists
+    And the summary contains the disclaimer

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -49,6 +49,21 @@ def run_analyse_directory_pdf_option(context, dir, pdfout):
     run_analyse_pdf_option(context, dir, pdfout)
 
 
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" in outdir "(?P<dir>[^"]+)"')
+def run_analyse_outdir(context, pdf, dir):
+    root = Path(__file__).resolve().parents[2]
+    out = root / dir
+    context.summary_path = out / "summary.csv"
+    if context.summary_path.exists():
+        context.summary_path.unlink()
+    out.mkdir(exist_ok=True)
+    context.result = subprocess.run(
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf), "--outdir", dir],
+        capture_output=True,
+        cwd=root,
+    )
+
+
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with terminal output')
 def run_analyse_terminal_option(context, pdf):
     root = Path(__file__).resolve().parents[2]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typer.testing import CliRunner
+
+from bankcleanr.cli import app, SAMPLE_STATEMENT
+from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
+
+
+def test_analyse_outdir_creates_files(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "analyse",
+            str(SAMPLE_STATEMENT),
+            "--outdir",
+            str(tmp_path),
+            "--pdf",
+            "report.pdf",
+        ],
+    )
+    assert result.exit_code == 0
+    csv = tmp_path / "summary.csv"
+    pdf = tmp_path / "report.pdf"
+    assert csv.exists()
+    assert pdf.exists()
+    assert GLOBAL_DISCLAIMER in csv.read_text()


### PR DESCRIPTION
## Summary
- allow `bankcleanr analyse` to place outputs in a directory
- document `--outdir` usage in README and CLI help
- add new unit tests for `analyse` and directory output
- cover outdir behaviour in BDD tests

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_687235990f5c832bb0cf9c9fb22245b0