### PR TITLE
Improve PDF summary formatting

### DIFF
--- a/bankcleanr/reports/writer.py
+++ b/bankcleanr/reports/writer.py
@@ -101,7 +101,7 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
             gathered_cats.add(cat)
         tx_rows.append([
             t["date"],
-            t["description"],
+            Paragraph(str(t["description"]), styles["Normal"]),
             t["amount"],
             t["balance"],
             cat,
@@ -114,7 +114,20 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
         categories = sorted(gathered_cats)
 
     elements = [Paragraph("Transactions", styles["Heading2"])]
-    table = Table(tx_rows)
+
+    col_widths = [
+        doc.width * 0.1,  # date
+        doc.width * 0.35,  # description
+        doc.width * 0.08,  # amount
+        doc.width * 0.08,  # balance
+        doc.width * 0.1,  # category
+        doc.width * 0.06,  # action
+        doc.width * 0.1,  # url
+        doc.width * 0.1,  # email
+        doc.width * 0.13,  # phone
+    ]
+
+    table = Table(tx_rows, colWidths=col_widths)
     table.setStyle(
         TableStyle(
             [

--- a/tests/test_io_writer.py
+++ b/tests/test_io_writer.py
@@ -75,6 +75,21 @@ def test_write_pdf_summary(tmp_path):
     assert GLOBAL_DISCLAIMER.replace("\n", " ") in text.replace("\n", " ")
 
 
+def test_write_pdf_summary_long_description(tmp_path):
+    long_desc = "Very long description " * 10
+    transactions = [
+        {"date": "2023-01-01", "description": long_desc, "amount": "-1.00", "balance": "99.00"},
+    ]
+    output = tmp_path / "long.pdf"
+    write_pdf_summary(transactions, str(output), [])
+
+    with pdfplumber.open(output) as pdf:
+        text = " ".join(page.extract_text() or "" for page in pdf.pages)
+
+    extracted = "".join(text.split())
+    assert extracted.count("Verylongdescription") >= 10
+
+
 def test_format_terminal_summary():
     transactions = [
         {"date": "2023-01-01", "description": "Coffee", "amount": "-1.00", "balance": "99.00"},


### PR DESCRIPTION
## Summary
- wrap long descriptions with `Paragraph`
- set column widths in `write_pdf_summary`
- test long description handling in PDF summaries

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68726240eb14832bb694b297cf91109b