### PR TITLE
Enable LLM recs in CLI

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -57,3 +57,9 @@ Feature: Command-line interface
     Then the exit code is 0
     And the summary file exists
     And the summary contains the disclaimer
+
+  Scenario: Analyse a PDF statement with LLM classification
+    Given an API key is configured
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf"
+    Then the exit code is 0
+    And the summary actions include "Investigate"

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,12 @@
+import os
+
+def after_scenario(context, scenario):
+    if "_orig_key" in context.__dict__:
+        if context._orig_key is None:
+            os.environ.pop("OPENAI_API_KEY", None)
+        else:
+            os.environ["OPENAI_API_KEY"] = context._orig_key
+        try:
+            delattr(context, "_orig_key")
+        except Exception:
+            pass

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -1,8 +1,9 @@
-from behave import when, then
+from behave import given, when, then
 import subprocess
 from pathlib import Path
 import re
 from behave import use_step_matcher
+import os
 from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
 
 use_step_matcher("re")
@@ -133,3 +134,18 @@ def terminal_output_contains_disclaimer_once(context):
 def terminal_output_shows_savings(context):
     output = context.result.stdout.decode().lower()
     assert "potential savings" in output
+
+
+@given("an API key is configured")
+def api_key_configured(context):
+    context._orig_key = os.getenv("OPENAI_API_KEY")
+    os.environ["OPENAI_API_KEY"] = "dummy"
+
+
+@then(r'the summary actions include "(?P<label>[^"]+)"')
+def summary_actions_include(context, label):
+    import csv
+    with open(context.summary_path) as f:
+        reader = csv.DictReader(f)
+        acts = [row["action"] for row in reader]
+    assert label in acts


### PR DESCRIPTION
## Summary
- generate recommendations with `recommend_transactions`
- test CLI behaviour when an API key is present
- restore environment variables between Behave scenarios

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a6ada224832ba0be83e30726d7ec