### PR TITLE
Fix OpenAI adapter to use ainvoke

### DIFF
--- a/bankcleanr/llm/openai.py
+++ b/bankcleanr/llm/openai.py
@@ -31,7 +31,7 @@ class OpenAIAdapter(AbstractAdapter):
         async with self._sem:
             prompt = CATEGORY_PROMPT.render(description=tx.description)
             message = HumanMessage(content=prompt)
-            result = await self.llm.apredict_messages([message])
+            result = await self.llm.ainvoke([message])
         try:
             data = json.loads(result.content)
             if not isinstance(data, dict):

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -98,7 +98,7 @@ def counting_stub(context):
             self.running = 0
             self.max_running = 0
 
-        async def apredict_messages(self, messages):
+        async def ainvoke(self, messages):
             self.running += 1
             self.max_running = max(self.max_running, self.running)
             await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary
- switch deprecated `apredict_messages` to `ainvoke`
- update feature stubs and unit tests
- cover JSON parsing through new test

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bec08894832b95f7f8dd447fd2b3