### PR TITLE
Fix Gemini adapter to use new google genai client

### DIFF
--- a/bankcleanr/llm/gemini.py
+++ b/bankcleanr/llm/gemini.py
@@ -10,16 +10,16 @@ from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 
 class GeminiAdapter(AbstractAdapter):
-    def __init__(self, model: str = "gemini-pro", api_key: str | None = None):
+    def __init__(self, model: str = "gemini-2.5-flash", api_key: str | None = None):
         """Initialise the Gemini adapter and underlying client."""
         try:
-            import google.generativeai as genai  # type: ignore
+            from google import genai  # type: ignore
         except Exception as exc:  # pragma: no cover - library may not be installed
             print(f"[GeminiAdapter] failed to import SDK: {exc}")
             self.client = None
         else:
             genai.configure(api_key=api_key)
-            self.client = genai.GenerativeModel(model)
+            self.client = genai.Client()
             print(f"[GeminiAdapter] initialised model={model}")
         self.model = model
 
@@ -34,14 +34,19 @@ class GeminiAdapter(AbstractAdapter):
             prompt = CATEGORY_PROMPT.render(description=tx.description)
             print(f"[GeminiAdapter] prompt: {prompt}")
             try:
-                resp = self.client.generate_content(prompt, stream=False)
+                resp = self.client.models.generate_content(
+                    model=self.model, contents=prompt
+                )
                 print(f"[GeminiAdapter] raw response: {resp}")
-                message = resp.text if hasattr(resp, "text") else resp.candidates[0].content
+                message = (
+                    resp.text if hasattr(resp, "text") else resp.candidates[0].content
+                )
                 print(f"[GeminiAdapter] message: {message}")
                 labels.append(message.strip().lower())
             except Exception as exc:
                 print(f"[GeminiAdapter] error: {exc}")
                 import traceback
+
                 traceback.print_exc()
                 labels.append("unknown")
         return labels


### PR DESCRIPTION
## Summary
- update GeminiAdapter to use `genai.Client` and new `models.generate_content` call
- default Gemini model updated to `gemini-2.5-flash`

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_68739e847960832ba789d446166dd40c