### PR TITLE
Add verbose progress flag

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -42,10 +42,15 @@ def analyse(
     terminal: bool = typer.Option(
         False, "--terminal", help="Display the summary in the terminal"
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="Show each file as it is processed",
+    ),
 ):
     """Analyse a statement file or directory and write a summary."""
     typer.echo(f"Analysing {path}")
-    transactions = load_from_path(path)
+    transactions = load_from_path(path, verbose=verbose)
 
     settings = get_settings()
     if settings.api_key:

--- a/bankcleanr/io/loader.py
+++ b/bankcleanr/io/loader.py
@@ -10,12 +10,20 @@ def load_transactions(path: str) -> List[Mapping]:
     raise ValueError("Unsupported file type")
 
 
-def load_from_path(path: str) -> List[Mapping]:
-    """Load transactions from a file or directory of PDF files."""
+def load_from_path(path: str, *, verbose: bool = False) -> List[Mapping]:
+    """Load transactions from a file or directory of PDF files.
+
+    If ``verbose`` is ``True`` the path of each processed PDF file will be
+    printed to stdout before parsing.
+    """
     p = Path(path)
     if p.is_dir():
         transactions: List[Mapping] = []
         for pdf in sorted(p.glob("*.pdf")):
+            if verbose:
+                print(str(pdf))
             transactions.extend(load_transactions(str(pdf)))
         return transactions
+    if verbose:
+        print(str(p))
     return load_transactions(str(p))

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -63,3 +63,8 @@ Feature: Command-line interface
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf"
     Then the exit code is 0
     And the summary actions include "Investigate"
+
+  Scenario: Analyse a PDF statement with verbose output
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with verbose output
+    Then the exit code is 0
+    And the terminal output contains "22b583f5-4060-44eb-a844-945cd612353c (1).pdf"

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -75,6 +75,19 @@ def run_analyse_terminal_option(context, pdf):
     )
 
 
+@when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with verbose output')
+def run_analyse_verbose_option(context, pdf):
+    root = Path(__file__).resolve().parents[2]
+    context.summary_path = root / "summary.csv"
+    if context.summary_path.exists():
+        context.summary_path.unlink()
+    context.result = subprocess.run(
+        ["python", "-m", "bankcleanr", "analyse", str(root / pdf), "--verbose"],
+        capture_output=True,
+        cwd=root,
+    )
+
+
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" to "(?P<outfile>[^"]+)" with terminal output')
 def run_analyse_output_terminal(context, pdf, outfile):
     """Run analyse writing to a file and showing terminal output."""
@@ -128,6 +141,12 @@ def terminal_output_contains_disclaimer_once(context):
     """Ensure the disclaimer appears exactly once in terminal output."""
     output = context.result.stdout.decode()
     assert output.count(GLOBAL_DISCLAIMER) == 1
+
+
+@then(r'the terminal output contains "(?P<text>[^"]+)"')
+def terminal_output_contains_text(context, text):
+    output = context.result.stdout.decode()
+    assert text in output
 
 
 @then('the terminal output shows savings')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,3 +24,21 @@ def test_analyse_outdir_creates_files(tmp_path):
     assert csv.exists()
     assert pdf.exists()
     assert GLOBAL_DISCLAIMER in csv.read_text()
+
+
+def test_analyse_verbose_outputs_paths(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "analyse",
+            str(SAMPLE_STATEMENT),
+            "--outdir",
+            str(tmp_path),
+            "--verbose",
+        ],
+    )
+    assert result.exit_code == 0
+    csv = tmp_path / "summary.csv"
+    assert csv.exists()
+    assert str(SAMPLE_STATEMENT) in result.stdout

--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -6,7 +6,7 @@ import pytest
 from bankcleanr.io import loader
 
 
-def test_load_from_path_file(monkeypatch, tmp_path):
+def test_load_from_path_file(monkeypatch, tmp_path, capsys):
     called = []
 
     def fake_load(path):
@@ -17,12 +17,14 @@ def test_load_from_path_file(monkeypatch, tmp_path):
     pdf = tmp_path / "file.pdf"
     pdf.write_text("dummy")
 
-    result = loader.load_from_path(str(pdf))
+    result = loader.load_from_path(str(pdf), verbose=True)
+    captured = capsys.readouterr()
     assert result == ["tx"]
     assert called == [str(pdf)]
+    assert str(pdf) in captured.out
 
 
-def test_load_from_path_directory(monkeypatch, tmp_path):
+def test_load_from_path_directory(monkeypatch, tmp_path, capsys):
     order = []
 
     def fake_load(path):
@@ -34,6 +36,9 @@ def test_load_from_path_directory(monkeypatch, tmp_path):
     (tmp_path / "b.pdf").write_text("b")
     (tmp_path / "a.pdf").write_text("a")
 
-    result = loader.load_from_path(str(tmp_path))
+    result = loader.load_from_path(str(tmp_path), verbose=True)
+    captured = capsys.readouterr()
     assert order == ["a.pdf", "b.pdf"]
     assert result == [str(tmp_path / "a.pdf"), str(tmp_path / "b.pdf")]
+    assert str(tmp_path / "a.pdf") in captured.out
+    assert str(tmp_path / "b.pdf") in captured.out


### PR DESCRIPTION
## Summary
- extend `analyse` CLI command with `--verbose` flag
- echo each file processed when verbose flag is set
- support verbose flag in loader
- add tests for verbose CLI behaviour and loader output
- document verbose scenario in BDD features

## Testing
- `make unit`
- `make behave`


------
https://chatgpt.com/codex/tasks/task_e_6873d5b70090832ba2bfb22652646580