### PR TITLE
Add connectivity pre-check for live LLM tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ provider:
 Export the appropriate variable before running the CLI so the adapter can talk
 to the LLM service.
 
+When running the behaviour tests, the live classification steps verify that the
+API key isn't a placeholder and perform a short connectivity check. If this
+probe fails the scenario is skipped so the suite can run without valid
+credentials or network access.
+
 Run `poetry run bankcleanr config` to see which configuration file is in use.
 
 ### LLM workflow

--- a/bankcleanr/llm/utils.py
+++ b/bankcleanr/llm/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from typing import Iterable
+
+from bankcleanr.transaction import Transaction
+from .base import AbstractAdapter
+
+
+def probe_adapter(adapter: AbstractAdapter, timeout: float = 5.0) -> bool:
+    """Send a simple request to verify the adapter is reachable."""
+    tx = Transaction(date="1970-01-01", description="probe", amount="0")
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(adapter.classify_transactions, [tx])
+        try:
+            labels = future.result(timeout=timeout)
+        except FutureTimeoutError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("timed out") from exc
+    if not labels or labels[0] == "unknown":
+        raise RuntimeError("no valid response")
+    return True

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -138,17 +138,11 @@ def classify_live(context, provider):
         "bfl": "BFL_API_KEY",
         "gemini": "GEMINI_API_KEY",
     }
-    print("****env_map**")
-    print(env_map)
-    print("**********************************************************************")
 
     if provider not in PROVIDERS:
         raise AssertionError(f"{provider} adapter not available")
     env_var = env_map.get(provider)
     api_key = os.getenv(env_var) if env_var else None
-    print("**********************api_key***********************************")
-    print(api_key)
-    print("**********************************************************************")
     placeholders = {"dummy", "your-openai-api-key", "your-api-key", "your-gemini-api-key"}
     if env_var and (
         api_key is None or api_key.lower() in placeholders
@@ -157,17 +151,17 @@ def classify_live(context, provider):
         return
     adapter_cls = PROVIDERS[provider]
     adapter = adapter_cls(api_key=api_key)
-    print("**************************adapter**********************************")
-    print(adapter)
-    print("**********************************************************************")
     client = getattr(adapter, "client", getattr(adapter, "delegate", None))
     if client is None:
         context.scenario.skip("provider not available")
         return
+    try:
+        from bankcleanr.llm.utils import probe_adapter
+        probe_adapter(adapter, timeout=5)
+    except Exception as exc:
+        context.scenario.skip(f"connectivity check failed: {exc}")
+        return
     context.labels = adapter.classify_transactions(context.txs)
-    print("*************************context.labels********************************")
-    print(context.labels)
-    print("**********************************************************************")
 
 
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,31 @@
+import time
+import pytest
+
+from bankcleanr.llm.utils import probe_adapter
+from bankcleanr.llm.base import AbstractAdapter
+
+
+class DummyAdapter(AbstractAdapter):
+    def __init__(self, delay=0, raise_exc=False):
+        self.delay = delay
+        self.raise_exc = raise_exc
+
+    def classify_transactions(self, transactions):
+        if self.raise_exc:
+            raise RuntimeError("fail")
+        time.sleep(self.delay)
+        return ["ok" for _ in transactions]
+
+
+def test_probe_adapter_success():
+    assert probe_adapter(DummyAdapter()) is True
+
+
+def test_probe_adapter_timeout():
+    with pytest.raises(RuntimeError):
+        probe_adapter(DummyAdapter(delay=1), timeout=0.01)
+
+
+def test_probe_adapter_failure():
+    with pytest.raises(RuntimeError):
+        probe_adapter(DummyAdapter(raise_exc=True))


### PR DESCRIPTION
## Summary
- add `probe_adapter` utility to validate adapters
- skip live scenarios if adapter can't be reached
- document new skip logic
- test the new utility

## Testing
- `poetry run pytest -q`
- `poetry run behave -q`

------
https://chatgpt.com/codex/tasks/task_e_6873dbf015bc832b9198a8a20080b126