### PR TITLE
Handle income and expense columns

### DIFF
--- a/bankcleanr/analytics.py
+++ b/bankcleanr/analytics.py
@@ -40,7 +40,8 @@ def calculate_savings(recommendations: Iterable[Recommendation]) -> Decimal:
             else:
                 amt_str = _get_attr(rec, "amount", "0")
             amt = _parse_amount(amt_str)
-            total += abs(amt)
+            if amt < 0:
+                total += abs(amt)
     return total
 
 
@@ -55,7 +56,8 @@ def totals_by_type(recommendations: Iterable[Recommendation]) -> Dict[str, Decim
         else:
             amt_str = _get_attr(rec, "amount", "0")
         amt = _parse_amount(amt_str)
-        totals[group] = totals.get(group, Decimal("0")) + abs(amt)
+        if amt < 0:
+            totals[group] = totals.get(group, Decimal("0")) + abs(amt)
     return totals
 
 

--- a/bankcleanr/io/pdf/generic.py
+++ b/bankcleanr/io/pdf/generic.py
@@ -13,12 +13,35 @@ LINE_RE = re.compile(
     r"^(?P<date>\d{1,2} \w+)\s+(?P<description>.+?)\s+(?P<amount>-?\d+\.\d{2})(?:\s+(?P<balance>-?\d+\.\d{2}))?$"
 )
 
+LINE_IN_OUT_RE = re.compile(
+    r"^(?P<date>\d{1,2} \w+)\s+(?P<description>.+?)\s+(?P<money_out>\d+\.\d{2})\s+(?P<money_in>\d+\.\d{2})\s+(?P<balance>-?\d+\.\d{2})$"
+)
+
 
 def _parse_lines(lines: List[str]) -> List[Transaction]:
     """Parse lines of text into Transaction objects."""
     rows = []
     for line in lines:
-        match = LINE_RE.match(line.strip())
+        text = line.strip()
+        match = LINE_IN_OUT_RE.match(text)
+        if match:
+            data = match.groupdict()
+            money_in = data.get("money_in", "")
+            money_out = data.get("money_out", "")
+            if money_in and money_in != "0.00":
+                amount = money_in
+            else:
+                amount = f"-{money_out.lstrip('-')}" if money_out else ""
+            rows.append(
+                Transaction(
+                    date=data.get("date", ""),
+                    description=data.get("description", ""),
+                    amount=amount,
+                    balance=data.get("balance", ""),
+                )
+            )
+            continue
+        match = LINE_RE.match(text)
         if match:
             data = match.groupdict()
             rows.append(
@@ -43,16 +66,41 @@ def parse_pdf(path: str) -> List[Transaction]:
                 parsed_rows: List[Transaction] = []
                 if table and len(table) > 1:
                     header, *body = table
+                    header_clean = [h.strip().lower() if h else "" for h in header]
+                    has_in_out = "money in" in header_clean and "money out" in header_clean
                     for row in body:
                         if len(row) >= 4:
-                            parsed_rows.append(
-                                Transaction(
-                                    date=row[0].strip(),
-                                    description=row[1].strip(),
-                                    amount=row[2].strip(),
-                                    balance=row[3].strip() if len(row) > 3 else "",
+                            if has_in_out:
+                                idx_date = header_clean.index("date") if "date" in header_clean else 0
+                                idx_desc = header_clean.index("description") if "description" in header_clean else 1
+                                idx_out = header_clean.index("money out")
+                                idx_in = header_clean.index("money in")
+                                idx_balance = header_clean.index("balance") if "balance" in header_clean else 4
+                                money_in = row[idx_in].strip() if idx_in < len(row) else ""
+                                money_out = row[idx_out].strip() if idx_out < len(row) else ""
+                                amount = ""
+                                if money_in:
+                                    amount = money_in.strip()
+                                elif money_out:
+                                    mo = money_out.strip().lstrip("+")
+                                    amount = f"-{mo.lstrip('-')}" if mo else ""
+                                parsed_rows.append(
+                                    Transaction(
+                                        date=row[idx_date].strip(),
+                                        description=row[idx_desc].strip(),
+                                        amount=amount,
+                                        balance=row[idx_balance].strip() if idx_balance < len(row) else "",
+                                    )
                                 )
-                            )
+                            else:
+                                parsed_rows.append(
+                                    Transaction(
+                                        date=row[0].strip(),
+                                        description=row[1].strip(),
+                                        amount=row[2].strip(),
+                                        balance=row[3].strip() if len(row) > 3 else "",
+                                    )
+                                )
                     accuracy = len(parsed_rows) / (len(body) or 1)
                     if accuracy < 0.8:
                         parsed_rows = _parse_lines(page.extract_text().splitlines())

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -1,0 +1,5 @@
+Feature: Analytics functions
+  Scenario: Totals exclude income
+    Given recommendations including income
+    When I total recommendations by type
+    Then income amounts are excluded from totals

--- a/features/parser.feature
+++ b/features/parser.feature
@@ -3,3 +3,8 @@ Feature: PDF parser
     Given a minimal statement PDF
     When I parse the file
     Then the parser returns two transactions
+
+  Scenario: Parse statement with Money in/out columns
+    Given a statement PDF with Money in and out columns
+    When I parse the file
+    Then the amounts reflect income and expenses

--- a/features/steps/analytics_steps.py
+++ b/features/steps/analytics_steps.py
@@ -1,0 +1,26 @@
+from behave import given, when, then
+from decimal import Decimal
+
+from bankcleanr.transaction import Transaction
+from bankcleanr.recommendation import Recommendation
+from bankcleanr.analytics import totals_by_type
+
+
+@given("recommendations including income")
+def recs_with_income(context):
+    context.recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Spotify", amount="-9.99"), "spotify", "Cancel"),
+        Recommendation(Transaction(date="2024-01-02", description="Salary", amount="1000.00"), "salary", "Keep"),
+        Recommendation(Transaction(date="2024-01-03", description="Bus", amount="-2.50"), "bus", "Keep"),
+    ]
+
+
+@when("I total recommendations by type")
+def total_by_type(context):
+    context.totals = totals_by_type(context.recs)
+
+
+@then("income amounts are excluded from totals")
+def check_totals(context):
+    assert context.totals["entertainment"] == Decimal("9.99")
+    assert context.totals["other"] == Decimal("2.50")

--- a/features/steps/parser_steps.py
+++ b/features/steps/parser_steps.py
@@ -43,3 +43,19 @@ def parse_file(context):
 def check_transactions(context):
     assert len(context.transactions) == 2
     assert context.transactions[0].description == "Coffee"
+
+
+@given("a statement PDF with Money in and out columns")
+def given_in_out_pdf(context):
+    rows = [
+        ["Date", "Description", "Money out", "Money in", "Balance"],
+        ["01 Jan", "Coffee", "1.00", "0.00", "99.00"],
+        ["02 Jan", "Salary", "0.00", "100.00", "199.00"],
+    ]
+    context.pdf_path = _create_pdf(rows)
+
+
+@then("the amounts reflect income and expenses")
+def check_amount_signs(context):
+    assert context.transactions[0].amount == "-1.00"
+    assert context.transactions[1].amount == "100.00"

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -12,6 +12,14 @@ def test_calculate_savings():
     assert calculate_savings(recs) == Decimal("9.99")
 
 
+def test_calculate_savings_ignores_income():
+    recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Refund", amount="5.00"), "refund", "Cancel"),
+        Recommendation(Transaction(date="2024-01-02", description="Spotify", amount="-9.99"), "spotify", "Cancel"),
+    ]
+    assert calculate_savings(recs) == Decimal("9.99")
+
+
 def test_totals_by_type():
     recs = [
         Recommendation(Transaction(date="2024-01-01", description="Spotify", amount="-9.99"), "spotify", "Cancel"),
@@ -21,6 +29,15 @@ def test_totals_by_type():
     totals = totals_by_type(recs)
     assert totals["entertainment"] == Decimal("9.99")
     assert totals["cloud"] == Decimal("5.00")
+    assert totals["other"] == Decimal("2.50")
+
+
+def test_totals_by_type_ignores_income():
+    recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Salary", amount="1000.00"), "salary", "Keep"),
+        Recommendation(Transaction(date="2024-01-02", description="Bus", amount="-2.50"), "bus", "Keep"),
+    ]
+    totals = totals_by_type(recs)
     assert totals["other"] == Decimal("2.50")
 
 

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -38,6 +38,21 @@ def test_parse_pdf_regex():
     assert txs[1].amount == "-2.00"
 
 
+def test_parse_money_in_out_columns():
+    rows = [
+        ["Date", "Description", "Money out", "Money in", "Balance"],
+        ["01 Jan", "Coffee", "1.00", "0.00", "99.00"],
+        ["02 Jan", "Salary", "0.00", "100.00", "199.00"],
+    ]
+    path = _make_simple_pdf(rows)
+    try:
+        txs = generic.parse_pdf(path)
+    finally:
+        os.unlink(path)
+    assert txs[0].amount == "-1.00"
+    assert txs[1].amount == "100.00"
+
+
 def test_parse_pdf_ocr_fallback(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- detect Money in/out columns in generic PDF parser
- keep sign on parsed amounts
- treat only negative amounts in analytics savings and totals
- test PDF parser and analytics for income vs expense
- add BDD tests for new behaviour

## Testing
- `pytest -q`
- `behave -q`


------
https://chatgpt.com/codex/tasks/task_e_6878066b1e20832b91e05cdb28cbf796