### PR TITLE
Add new expense categories

### DIFF
--- a/bankcleanr/analytics.py
+++ b/bankcleanr/analytics.py
@@ -8,10 +8,16 @@ from .recommendation import Recommendation
 # Map transaction categories to high level types
 CATEGORY_TYPES = {
     "spotify": "entertainment",
-    "netflix": "entertainment",
-    "amazon prime": "entertainment",
+    "netflix": "tv subscription",
+    "amazon prime": "tv subscription",
     "icloud": "cloud",
     "dropbox": "cloud",
+    "tesco": "grocery",
+    "walmart": "grocery",
+    "openai": "ai",
+    "midjourney": "ai",
+    "bus": "transport",
+    "uber": "transport",
 }
 
 

--- a/features/steps/analytics_steps.py
+++ b/features/steps/analytics_steps.py
@@ -23,4 +23,4 @@ def total_by_type(context):
 @then("income amounts are excluded from totals")
 def check_totals(context):
     assert context.totals["entertainment"] == Decimal("9.99")
-    assert context.totals["other"] == Decimal("2.50")
+    assert context.totals["transport"] == Decimal("2.50")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -29,7 +29,7 @@ def test_totals_by_type():
     totals = totals_by_type(recs)
     assert totals["entertainment"] == Decimal("9.99")
     assert totals["cloud"] == Decimal("5.00")
-    assert totals["other"] == Decimal("2.50")
+    assert totals["transport"] == Decimal("2.50")
 
 
 def test_totals_by_type_ignores_income():
@@ -38,7 +38,19 @@ def test_totals_by_type_ignores_income():
         Recommendation(Transaction(date="2024-01-02", description="Bus", amount="-2.50"), "bus", "Keep"),
     ]
     totals = totals_by_type(recs)
-    assert totals["other"] == Decimal("2.50")
+    assert totals["transport"] == Decimal("2.50")
+
+
+def test_totals_by_type_new_groups():
+    recs = [
+        Recommendation(Transaction(date="2024-01-01", description="Tesco", amount="-15.00"), "tesco", "Keep"),
+        Recommendation(Transaction(date="2024-01-02", description="OpenAI", amount="-20.00"), "openai", "Keep"),
+        Recommendation(Transaction(date="2024-01-03", description="Netflix", amount="-7.00"), "netflix", "Keep"),
+    ]
+    totals = totals_by_type(recs)
+    assert totals["grocery"] == Decimal("15.00")
+    assert totals["ai"] == Decimal("20.00")
+    assert totals["tv subscription"] == Decimal("7.00")
 
 
 def test_summarize_by_description():


### PR DESCRIPTION
## Summary
- support new groups like grocery, ai, tv subscription and transport
- expand test coverage for the new groups
- update behaviour checks for transport totals

## Testing
- `make unit`
- `make behave`


------
https://chatgpt.com/codex/tasks/task_e_6878093dfa68832b80df79bce8f3501a