### PR TITLE
Load heuristics from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ PDF output is only produced when you pass `--pdf` or give an `--output`
 filename ending in `.pdf`. The command always reminds you to verify each
 recommendation manually.
 
+### Updating heuristics
+
+Regex patterns for the local classifier live in `bankcleanr/data/heuristics.yml`.
+After LLM classification the tool asks if newly labelled descriptions should be
+added to this file. Confirm with `y` to store the pattern so future runs
+recognise it. You can also edit the YAML manually if needed.
+
 ## Disclaimer
 
 Every summary includes the following disclaimer:

--- a/bankcleanr/data/heuristics.yml
+++ b/bankcleanr/data/heuristics.yml
@@ -1,0 +1,5 @@
+spotify: 'spotify'
+netflix: 'netflix'
+icloud: 'icloud'
+amazon prime: 'amazon\s+prime'
+dropbox: 'dropbox'

--- a/bankcleanr/recommendation.py
+++ b/bankcleanr/recommendation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Callable
 
 import yaml
 
@@ -34,10 +34,11 @@ def recommend_transactions(
     transactions: Iterable,
     provider: str | None = None,
     kb_path: Path = KB_PATH,
+    confirm: Callable[[str], str] | None = None,
 ) -> List[Recommendation]:
     """Return recommendations for each transaction."""
     txs = [normalise(tx) for tx in transactions]
-    labels = classify_transactions(txs, provider=provider)
+    labels = classify_transactions(txs, provider=provider, confirm=confirm)
     kb = load_knowledge_base(kb_path)
     results: List[Recommendation] = []
     for tx, label in zip(txs, labels):

--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -1,6 +1,7 @@
 """Local heuristics for quick transaction classification."""
 
-from typing import Iterable, List
+from typing import Iterable, List, Callable, Optional
+import sys
 
 from bankcleanr.transaction import Transaction, normalise
 from . import regex
@@ -13,3 +14,32 @@ def classify_transactions(transactions: Iterable) -> List[str]:
         tx_obj = normalise(tx)
         labels.append(regex.classify(tx_obj.description))
     return labels
+
+
+def learn_new_patterns(
+    transactions: Iterable[Transaction],
+    labels: Iterable[str],
+    confirm: Optional[Callable[[str], str]] = None,
+) -> None:
+    """Ask to store new regex patterns derived from LLM labels."""
+    if confirm is None:
+        def confirm(prompt: str) -> str:
+            if not sys.stdin.isatty():
+                return "n"
+            try:
+                return input(prompt)
+            except (EOFError, OSError):
+                return "n"
+
+    for tx, label in zip(transactions, labels):
+        if label == "unknown":
+            continue
+        current = regex.classify(tx.description)
+        if current == "unknown":
+            prompt = f"Add pattern for '{label}' matching '{tx.description}'? [y/N] "
+            answer = confirm(prompt)
+            if answer and answer.lower().startswith("y"):
+                regex.add_pattern(label, tx.description)
+                regex.reload_patterns()
+
+

--- a/bankcleanr/rules/regex.py
+++ b/bankcleanr/rules/regex.py
@@ -1,12 +1,37 @@
 import re
+from pathlib import Path
+import yaml
 
-PATTERNS = {
-    "spotify": re.compile(r"spotify", re.I),
-    "netflix": re.compile(r"netflix", re.I),
-    "icloud": re.compile(r"icloud", re.I),
-    "amazon prime": re.compile(r"amazon\s+prime", re.I),
-    "dropbox": re.compile(r"dropbox", re.I),
-}
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+HEURISTICS_PATH = DATA_DIR / "heuristics.yml"
+
+
+def _load_patterns(path: Path = HEURISTICS_PATH) -> dict[str, re.Pattern]:
+    """Load regex patterns from the heuristics YAML file."""
+    if path.exists():
+        data = yaml.safe_load(path.read_text()) or {}
+    else:
+        data = {}
+    return {label: re.compile(pattern, re.I) for label, pattern in data.items()}
+
+
+PATTERNS = _load_patterns()
+
+
+def reload_patterns(path: Path = HEURISTICS_PATH) -> None:
+    """Reload PATTERNS from the heuristics file."""
+    global PATTERNS
+    PATTERNS = _load_patterns(path)
+
+
+def add_pattern(label: str, pattern: str, path: Path = HEURISTICS_PATH) -> None:
+    """Append a new label→pattern mapping to the heuristics file."""
+    data = {}
+    if path.exists():
+        data = yaml.safe_load(path.read_text()) or {}
+    data[label] = pattern
+    path.write_text(yaml.safe_dump(data))
+    PATTERNS[label] = re.compile(pattern, re.I)
 
 def classify(description: str) -> str:
     """Return label if description matches a known pattern."""

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,4 +1,5 @@
 import os
+from bankcleanr.rules import regex
 
 def after_scenario(context, scenario):
     if "_orig_key" in context.__dict__:
@@ -10,3 +11,9 @@ def after_scenario(context, scenario):
             delattr(context, "_orig_key")
         except Exception:
             pass
+    if hasattr(context, "heuristics_path"):
+        regex.HEURISTICS_PATH = getattr(context, "orig_heuristics", regex.DATA_DIR / "heuristics.yml")
+        regex.reload_patterns()
+        delattr(context, "heuristics_path")
+        if hasattr(context, "orig_heuristics"):
+            delattr(context, "orig_heuristics")

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -8,3 +8,13 @@ Feature: Local heuristics classification
       | amazon prime |
       | dropbox |
       | unknown |
+
+  Scenario: Load patterns from YAML
+    Given a heuristics file containing
+      | label | pattern |
+      | gym   | gym membership |
+    And a transaction "Monthly gym membership"
+    When I classify transactions locally
+    Then the labels are
+      | label |
+      | gym |

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -51,7 +51,9 @@ def mock_named_adapter(context, provider, label):
 @when("I classify transactions with the LLM")
 def classify_with_llm(context):
     provider = getattr(context, "provider", "openai")
-    context.labels = classify_transactions(context.txs, provider=provider)
+    context.labels = classify_transactions(
+        context.txs, provider=provider, confirm=lambda _: "n"
+    )
 
 
 @then("the LLM labels are")
@@ -82,7 +84,7 @@ def classify_with_capture(context):
 
     context.original = PROVIDERS["openai"]
     PROVIDERS["openai"] = CaptureAdapter
-    classify_transactions(context.txs, provider="openai")
+    classify_transactions(context.txs, provider="openai", confirm=lambda _: "n")
     PROVIDERS["openai"] = context.original
 
 

--- a/features/steps/recommendation_steps.py
+++ b/features/steps/recommendation_steps.py
@@ -6,7 +6,9 @@ from bankcleanr import recommendation
 
 @when("I generate recommendations")
 def generate_recommendations(context):
-    context.recommendations = recommendation.recommend_transactions(context.txs, provider="openai")
+    context.recommendations = recommendation.recommend_transactions(
+        context.txs, provider="openai", confirm=lambda _: "n"
+    )
     if hasattr(context, "original"):
         PROVIDERS["openai"] = context.original
 

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,4 +1,7 @@
-from bankcleanr.rules.heuristics import classify_transactions
+import importlib
+import yaml
+from bankcleanr.rules import regex
+from bankcleanr.rules import heuristics
 from bankcleanr.transaction import Transaction
 
 
@@ -9,5 +12,24 @@ def test_classify_transactions():
         Transaction(date="2024-01-03", description="Dropbox subscription", amount="-11.99"),
         Transaction(date="2024-01-04", description="Coffee shop", amount="-2.50"),
     ]
-    labels = classify_transactions(txs)
+    labels = heuristics.classify_transactions(txs)
     assert labels == ["spotify", "amazon prime", "dropbox", "unknown"]
+
+
+def test_patterns_loaded_from_yaml(tmp_path, monkeypatch):
+    data = {"coffee": "coffee shop"}
+    path = tmp_path / "heuristics.yml"
+    path.write_text(yaml.safe_dump(data))
+
+    importlib.reload(regex)
+    monkeypatch.setattr(regex, "HEURISTICS_PATH", path, raising=False)
+    regex.reload_patterns(path)
+    importlib.reload(heuristics)
+
+    txs = [Transaction(date="2024-01-01", description="Coffee shop", amount="-1")]
+    labels = heuristics.classify_transactions(txs)
+    assert labels == ["coffee"]
+
+    # restore default patterns
+    importlib.reload(regex)
+    importlib.reload(heuristics)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -21,7 +21,7 @@ def test_llm_fallback(monkeypatch):
         Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
         Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
     ]
-    labels = classify_transactions(txs, provider="openai")
+    labels = classify_transactions(txs, provider="openai", confirm=lambda _: "n")
     assert labels == ["spotify", "remote"]
 
 
@@ -54,7 +54,7 @@ def test_llm_masks_before_sending(monkeypatch):
 
     monkeypatch.setitem(PROVIDERS, "openai", CaptureAdapter)
     txs = [Transaction(date="2024-01-01", description="Send 12-34-56 12345678", amount="-9.99")]
-    classify_transactions(txs, provider="openai")
+    classify_transactions(txs, provider="openai", confirm=lambda _: "n")
     assert captured["descriptions"][0] == "Send ****3456 ****5678"
 
 
@@ -64,7 +64,7 @@ def test_mistral_fallback(monkeypatch):
         Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
         Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
     ]
-    labels = classify_transactions(txs, provider="mistral")
+    labels = classify_transactions(txs, provider="mistral", confirm=lambda _: "n")
     assert labels == ["spotify", "remote"]
 
 
@@ -74,7 +74,7 @@ def test_gemini_fallback(monkeypatch):
         Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
         Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
     ]
-    labels = classify_transactions(txs, provider="gemini")
+    labels = classify_transactions(txs, provider="gemini", confirm=lambda _: "n")
     assert labels == ["spotify", "remote"]
 
 
@@ -84,7 +84,7 @@ def test_bfl_fallback(monkeypatch):
         Transaction(date="2024-01-01", description="Spotify premium", amount="-9.99"),
         Transaction(date="2024-01-02", description="Coffee shop", amount="-2.00"),
     ]
-    labels = classify_transactions(txs, provider="bfl")
+    labels = classify_transactions(txs, provider="bfl", confirm=lambda _: "n")
     assert labels == ["spotify", "remote"]
 
 

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -24,11 +24,11 @@ def test_recommend_transactions(monkeypatch, tmp_path):
 
     txs = [Transaction(date="2024-01-01", description="Spotify", amount="-9.99")]
 
-    def dummy_classify(transactions, provider=None):
+    def dummy_classify(transactions, provider=None, confirm=None):
         return ["spotify"]
 
     monkeypatch.setattr("bankcleanr.recommendation.classify_transactions", dummy_classify)
-    recs = recommend_transactions(txs, kb_path=kb_file)
+    recs = recommend_transactions(txs, kb_path=kb_file, confirm=lambda _: "n")
     assert recs[0].category == "spotify"
     assert recs[0].action == "Cancel"
     assert recs[0].info["url"] == "cancel-url"


### PR DESCRIPTION
## Summary
- move regex patterns to `bankcleanr/data/heuristics.yml`
- load patterns from YAML and allow appending new ones
- prompt user to save new patterns after LLM classification
- document updating heuristics in README
- adjust CLI helpers and tests for new confirm parameter
- update BDD tests and environment hooks

## Testing
- `pytest`
- `behave`

------
https://chatgpt.com/codex/tasks/task_e_687815fe4110832baf7dcd5cbab22318