### PR TITLE
Embed heuristics and cancellation info in LLM prompts

### DIFF
--- a/bankcleanr/llm/anthropic.py
+++ b/bankcleanr/llm/anthropic.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 from typing import Iterable, List
+from pathlib import Path
 
 from .base import AbstractAdapter
 from bankcleanr.transaction import normalise, Transaction
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
 
 class AnthropicAdapter(AbstractAdapter):
-    def __init__(self, model: str = "claude-3-haiku-20240307", api_key: str | None = None):
+    def __init__(
+        self,
+        model: str = "claude-3-haiku-20240307",
+        api_key: str | None = None,
+        heuristics_path: Path = DATA_DIR / "heuristics.yml",
+        cancellation_path: Path = DATA_DIR / "cancellation.yml",
+    ):
         try:
             import anthropic
         except Exception:  # pragma: no cover - library may not be installed
@@ -18,6 +27,12 @@ class AnthropicAdapter(AbstractAdapter):
         else:
             self.client = anthropic.Anthropic(api_key=api_key)
         self.model = model
+        self.heuristics_text = (
+            heuristics_path.read_text() if heuristics_path.exists() else ""
+        )
+        self.cancellation_text = (
+            cancellation_path.read_text() if cancellation_path.exists() else ""
+        )
 
     def classify_transactions(self, transactions: Iterable) -> List[str]:
         tx_objs = [normalise(tx) for tx in transactions]
@@ -26,7 +41,11 @@ class AnthropicAdapter(AbstractAdapter):
 
         labels: List[str] = []
         for tx in tx_objs:
-            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            prompt = CATEGORY_PROMPT.render(
+                description=tx.description,
+                heuristics=self.heuristics_text,
+                cancellation=self.cancellation_text,
+            )
             resp = self.client.messages.create(
                 model=self.model,
                 max_tokens=5,

--- a/bankcleanr/llm/gemini.py
+++ b/bankcleanr/llm/gemini.py
@@ -3,18 +3,27 @@
 from __future__ import annotations
 
 from typing import Iterable, List
+from pathlib import Path
 import logging
 
 from .base import AbstractAdapter
 from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
 
 logger = logging.getLogger(__name__)
 
 
 class GeminiAdapter(AbstractAdapter):
-    def __init__(self, model: str = "gemini-2.5-flash", api_key: str | None = None):
+    def __init__(
+        self,
+        model: str = "gemini-2.5-flash",
+        api_key: str | None = None,
+        heuristics_path: Path = DATA_DIR / "heuristics.yml",
+        cancellation_path: Path = DATA_DIR / "cancellation.yml",
+    ):
         """Initialise the Gemini adapter and underlying client."""
         try:
             from google import genai  # type: ignore
@@ -26,6 +35,12 @@ class GeminiAdapter(AbstractAdapter):
             self.client = genai.Client()
             logger.debug("[GeminiAdapter] initialised model=%s", model)
         self.model = model
+        self.heuristics_text = (
+            heuristics_path.read_text() if heuristics_path.exists() else ""
+        )
+        self.cancellation_text = (
+            cancellation_path.read_text() if cancellation_path.exists() else ""
+        )
 
     def classify_transactions(self, transactions: Iterable) -> List[str]:
         tx_objs = [normalise(tx) for tx in transactions]
@@ -35,7 +50,11 @@ class GeminiAdapter(AbstractAdapter):
 
         labels: List[str] = []
         for tx in tx_objs:
-            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            prompt = CATEGORY_PROMPT.render(
+                description=tx.description,
+                heuristics=self.heuristics_text,
+                cancellation=self.cancellation_text,
+            )
             logger.debug("[GeminiAdapter] prompt: %s", prompt)
             try:
                 resp = self.client.models.generate_content(

--- a/bankcleanr/llm/local_ollama.py
+++ b/bankcleanr/llm/local_ollama.py
@@ -3,24 +3,44 @@
 from __future__ import annotations
 
 from typing import Iterable, List
+from pathlib import Path
 import requests
 
 from .base import AbstractAdapter
 from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
 
 class LocalOllamaAdapter(AbstractAdapter):
-    def __init__(self, model: str = "llama3", host: str = "http://localhost:11434", api_key: str | None = None):
+    def __init__(
+        self,
+        model: str = "llama3",
+        host: str = "http://localhost:11434",
+        api_key: str | None = None,
+        heuristics_path: Path = DATA_DIR / "heuristics.yml",
+        cancellation_path: Path = DATA_DIR / "cancellation.yml",
+    ):
         self.model = model
         self.host = host.rstrip("/")
         self.api_key = api_key
+        self.heuristics_text = (
+            heuristics_path.read_text() if heuristics_path.exists() else ""
+        )
+        self.cancellation_text = (
+            cancellation_path.read_text() if cancellation_path.exists() else ""
+        )
 
     def classify_transactions(self, transactions: Iterable) -> List[str]:
         tx_objs = [normalise(tx) for tx in transactions]
         labels: List[str] = []
         for tx in tx_objs:
-            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            prompt = CATEGORY_PROMPT.render(
+                description=tx.description,
+                heuristics=self.heuristics_text,
+                cancellation=self.cancellation_text,
+            )
             try:
                 resp = requests.post(
                     f"{self.host}/api/generate",

--- a/bankcleanr/llm/mistral.py
+++ b/bankcleanr/llm/mistral.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 from typing import Iterable, List
+from pathlib import Path
 
 from .base import AbstractAdapter
 from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
 
 class MistralAdapter(AbstractAdapter):
-    def __init__(self, model: str = "mistral-small", api_key: str | None = None):
+    def __init__(
+        self,
+        model: str = "mistral-small",
+        api_key: str | None = None,
+        heuristics_path: Path = DATA_DIR / "heuristics.yml",
+        cancellation_path: Path = DATA_DIR / "cancellation.yml",
+    ):
         try:
             from mistralai.client import MistralClient
         except Exception:  # pragma: no cover - library may not be installed
@@ -18,6 +27,12 @@ class MistralAdapter(AbstractAdapter):
         else:
             self.client = MistralClient(api_key=api_key)
         self.model = model
+        self.heuristics_text = (
+            heuristics_path.read_text() if heuristics_path.exists() else ""
+        )
+        self.cancellation_text = (
+            cancellation_path.read_text() if cancellation_path.exists() else ""
+        )
 
     def classify_transactions(self, transactions: Iterable) -> List[str]:
         tx_objs = [normalise(tx) for tx in transactions]
@@ -26,7 +41,11 @@ class MistralAdapter(AbstractAdapter):
 
         labels: List[str] = []
         for tx in tx_objs:
-            prompt = CATEGORY_PROMPT.render(description=tx.description)
+            prompt = CATEGORY_PROMPT.render(
+                description=tx.description,
+                heuristics=self.heuristics_text,
+                cancellation=self.cancellation_text,
+            )
             resp = self.client.chat(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],

--- a/bankcleanr/rules/prompts.py
+++ b/bankcleanr/rules/prompts.py
@@ -9,6 +9,12 @@ CATEGORY_PROMPT = Template(
       "reasons_to_cancel"   - list explaining why a user might cancel
       "checklist"           - step-by-step cancellation checklist
 
+    Known heuristics (label: pattern):
+    {{ heuristics }}
+
+    Known cancellation paths:
+    {{ cancellation }}
+
     Transaction: {{ description }}
     """
 )


### PR DESCRIPTION
## Summary
- read heuristics and cancellation YAML files in all LLM adapters
- expand CATEGORY_PROMPT with data placeholders
- pass loaded data when rendering prompts
- test OpenAI adapter prompt rendering with captured messages

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6fa738d8832b85508e242467bf64