### PR TITLE
Refresh heuristics after learning

### DIFF
--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -72,4 +72,9 @@ def classify_transactions(
 
     heuristics.learn_new_patterns(tx_objs, labels, confirm=confirm)
 
+    refreshed = heuristics.classify_transactions(tx_objs)
+    for idx in unmatched_indexes:
+        if refreshed[idx] != "unknown":
+            labels[idx] = refreshed[idx]
+
     return labels

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -27,3 +27,12 @@ Feature: LLM classification
     And the OpenAI API is replaced with a counting stub
     When I classify transactions with the throttled adapter
     Then no more than 5 concurrent requests were sent
+
+  Scenario: Learned patterns are applied immediately
+    Given an empty heuristics file
+    And a transaction "Coffee shop"
+    And the OpenAI adapter is mocked to return "coffee"
+    When I classify transactions with the LLM accepting new patterns
+    Then the LLM labels are
+      | label |
+      | coffee |


### PR DESCRIPTION
## Summary
- rerun heuristics after learning new patterns
- support accepting patterns in llm BDD tests
- ensure LLM details remain after refresh
- test reclassification logic and new scenario

## Testing
- `pytest -q`
- `behave -q`


------
https://chatgpt.com/codex/tasks/task_e_687b7fcd16a0832b8f4e89ce53b6961e