### PR TITLE
Add unmatched transaction summary helper

### DIFF
--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -1,7 +1,8 @@
 """Local heuristics for quick transaction classification."""
 
-from typing import Iterable, List, Callable, Optional
+from typing import Iterable, List, Callable, Optional, Tuple
 import sys
+from collections import OrderedDict
 
 from bankcleanr.transaction import Transaction, normalise
 from . import regex
@@ -14,6 +15,21 @@ def classify_transactions(transactions: Iterable) -> List[str]:
         tx_obj = normalise(tx)
         labels.append(regex.classify(tx_obj.description))
     return labels
+
+
+def group_unmatched_transactions(
+    transactions: Iterable[Transaction],
+    labels: Iterable[str],
+) -> List[Tuple[str, str, int]]:
+    """Return unmatched transactions grouped by description with counts."""
+    counts: OrderedDict[Tuple[str, str], int] = OrderedDict()
+    for tx, label in zip(transactions, labels):
+        if label == "unknown":
+            continue
+        if regex.classify(tx.description) == "unknown":
+            key = (label, tx.description)
+            counts[key] = counts.get(key, 0) + 1
+    return [(label, desc, count) for (label, desc), count in counts.items()]
 
 
 def learn_new_patterns(
@@ -31,18 +47,14 @@ def learn_new_patterns(
             except (EOFError, OSError):
                 return "n"
 
-    unique: list[tuple[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-    for tx, label in zip(transactions, labels):
-        if label == "unknown":
-            continue
-        if regex.classify(tx.description) == "unknown":
-            pair = (label, tx.description)
-            if pair not in seen:
-                seen.add(pair)
-                unique.append(pair)
+    groups = group_unmatched_transactions(transactions, labels)
+    if groups:
+        print("Unmatched transaction summary:")
+        for label, description, count in groups:
+            suffix = f" ({count})" if count > 1 else ""
+            print(f"- {description}{suffix} -> {label}")
 
-    for label, description in unique:
+    for label, description, _ in groups:
         prompt = f"Add pattern for '{label}' matching '{description}'? [y/N] "
         answer = confirm(prompt)
         if answer and answer.lower().startswith("y"):

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,8 @@
 import os
+from pathlib import Path
 from bankcleanr.rules import regex
+
+ORIG_HEURISTICS = (regex.DATA_DIR / "heuristics.yml").read_text()
 
 def after_scenario(context, scenario):
     if "_orig_key" in context.__dict__:
@@ -12,7 +15,11 @@ def after_scenario(context, scenario):
         except Exception:
             pass
     if hasattr(context, "heuristics_path"):
-        regex.HEURISTICS_PATH = getattr(context, "orig_heuristics", regex.DATA_DIR / "heuristics.yml")
+        regex.HEURISTICS_PATH = getattr(
+            context, "orig_heuristics", regex.DATA_DIR / "heuristics.yml"
+        )
+        # restore original heuristics file contents
+        regex.HEURISTICS_PATH.write_text(ORIG_HEURISTICS)
         regex.reload_patterns()
         delattr(context, "heuristics_path")
         if hasattr(context, "orig_heuristics"):

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -36,3 +36,15 @@ Feature: LLM classification
     Then the LLM labels are
       | label |
       | coffee |
+
+  Scenario: Summary of new pattern suggestions is shown once
+    Given an empty heuristics file
+    And duplicate transactions requiring LLM
+    And the OpenAI adapter is mocked to return "coffee"
+    When I classify transactions with the LLM summarising new patterns
+    Then the LLM labels are
+      | label |
+      | coffee |
+      | coffee |
+    And the summary output lists "Coffee shop" 2 times
+    And the user is prompted once for "Coffee shop"

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,5 +1,7 @@
 import importlib
 import yaml
+from io import StringIO
+import contextlib
 from bankcleanr.rules import regex
 from bankcleanr.rules import heuristics
 from bankcleanr.transaction import Transaction
@@ -50,9 +52,29 @@ def test_learn_new_patterns_prompts_once(monkeypatch):
     ]
     labels = ["coffee", "coffee"]
 
-    heuristics.learn_new_patterns(
-        txs, labels, confirm=lambda prompt: prompts.append(prompt) or "y"
-    )
+    out = StringIO()
+    with contextlib.redirect_stdout(out):
+        heuristics.learn_new_patterns(
+            txs, labels, confirm=lambda prompt: prompts.append(prompt) or "y"
+        )
 
+    assert "Coffee shop (2)" in out.getvalue()
     assert prompts == ["Add pattern for 'coffee' matching 'Coffee shop'? [y/N] "]
     assert added == [("coffee", "Coffee shop")]
+
+
+def test_group_unmatched_transactions(monkeypatch):
+    monkeypatch.setattr(regex, "classify", lambda d: "unknown")
+
+    txs = [
+        Transaction(date="2024-01-01", description="Coffee shop", amount="-1"),
+        Transaction(date="2024-01-02", description="Coffee shop", amount="-1"),
+        Transaction(date="2024-01-03", description="Book store", amount="-1"),
+    ]
+    labels = ["coffee", "coffee", "books"]
+
+    groups = heuristics.group_unmatched_transactions(txs, labels)
+    assert groups == [
+        ("coffee", "Coffee shop", 2),
+        ("books", "Book store", 1),
+    ]


### PR DESCRIPTION
## Summary
- group unmatched transactions before learning new patterns
- show single summary to user when learning patterns
- restore original heuristics file after scenarios
- add behaviour test for summary display
- test grouping helper logic

## Testing
- `make unit`
- `behave`

------
https://chatgpt.com/codex/tasks/task_e_687bafc32294832bb39498ec9a6edcb2