### PR TITLE
Add default results folder for CLI outputs

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -20,6 +20,9 @@ app = typer.Typer(help="BankCleanr CLI")
 
 LOG_LEVEL_ENV = "BANKCLEANR_LOG_LEVEL"
 
+# Default directory for CLI outputs
+DEFAULT_OUTDIR = Path("results")
+
 
 @app.callback()
 def main(log_level: str = typer.Option(None, help="Set log verbosity (e.g. DEBUG)")):
@@ -82,20 +85,14 @@ def analyse(
                 info = None
             recs.append(recommendation.Recommendation(tx, label, action, info))
 
-    outdir_path: Path | None = None
-    if outdir:
-        outdir_path = Path(outdir)
-        outdir_path.mkdir(parents=True, exist_ok=True)
+    outdir_path = Path(outdir) if outdir else DEFAULT_OUTDIR
+    outdir_path.mkdir(parents=True, exist_ok=True)
 
-    output_path = Path(output)
-    if outdir_path:
-        output_path = outdir_path / output_path.name
+    output_path = outdir_path / Path(output).name
     write_summary(recs, str(output_path))
 
     if pdf:
-        pdf_path = Path(pdf)
-        if outdir_path:
-            pdf_path = outdir_path / pdf_path.name
+        pdf_path = outdir_path / Path(pdf).name
         write_pdf_summary(recs, str(pdf_path))
     if terminal:
         typer.echo(format_terminal_summary(recs))

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -5,6 +5,7 @@ import re
 from behave import use_step_matcher
 import os
 from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
+from bankcleanr.cli import DEFAULT_OUTDIR
 
 use_step_matcher("re")
 
@@ -20,7 +21,7 @@ def check_exit(context):
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^\"]+)"(?: to "(?P<outfile>[^\"]+)")?')
 def run_analyse(context, pdf, outfile=None):
     root = Path(__file__).resolve().parents[2]
-    context.summary_path = root / (outfile or "summary.csv")
+    context.summary_path = root / DEFAULT_OUTDIR / (outfile or "summary.csv")
     if context.summary_path.exists():
         context.summary_path.unlink()
     context.result = subprocess.run(
@@ -34,7 +35,7 @@ def run_analyse(context, pdf, outfile=None):
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with pdf "(?P<pdfout>[^"]+)"')
 def run_analyse_pdf_option(context, pdf, pdfout):
     root = Path(__file__).resolve().parents[2]
-    context.summary_path = root / pdfout
+    context.summary_path = root / DEFAULT_OUTDIR / pdfout
     if context.summary_path.exists():
         context.summary_path.unlink()
     context.result = subprocess.run(
@@ -78,7 +79,7 @@ def run_analyse_terminal_option(context, pdf):
 @when(r'I run the bankcleanr analyse command with "(?P<pdf>[^"]+)" with verbose output')
 def run_analyse_verbose_option(context, pdf):
     root = Path(__file__).resolve().parents[2]
-    context.summary_path = root / "summary.csv"
+    context.summary_path = root / DEFAULT_OUTDIR / "summary.csv"
     if context.summary_path.exists():
         context.summary_path.unlink()
     context.result = subprocess.run(
@@ -92,7 +93,7 @@ def run_analyse_verbose_option(context, pdf):
 def run_analyse_output_terminal(context, pdf, outfile):
     """Run analyse writing to a file and showing terminal output."""
     root = Path(__file__).resolve().parents[2]
-    context.summary_path = root / outfile
+    context.summary_path = root / DEFAULT_OUTDIR / outfile
     if context.summary_path.exists():
         context.summary_path.unlink()
     context.result = subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typer.testing import CliRunner
 
-from bankcleanr.cli import app, SAMPLE_STATEMENT
+from bankcleanr.cli import app, SAMPLE_STATEMENT, DEFAULT_OUTDIR
 from bankcleanr.reports.disclaimers import GLOBAL_DISCLAIMER
 
 
@@ -42,3 +42,23 @@ def test_analyse_verbose_outputs_paths(tmp_path):
     csv = tmp_path / "summary.csv"
     assert csv.exists()
     assert str(SAMPLE_STATEMENT) in result.stdout
+
+
+def test_analyse_default_outdir(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "analyse",
+                str(SAMPLE_STATEMENT),
+                "--pdf",
+                "report.pdf",
+            ],
+        )
+        assert result.exit_code == 0
+        csv = Path(DEFAULT_OUTDIR) / "summary.csv"
+        pdf = Path(DEFAULT_OUTDIR) / "report.pdf"
+        assert csv.exists()
+        assert pdf.exists()
+        assert GLOBAL_DISCLAIMER in csv.read_text()


### PR DESCRIPTION
## Summary
- add `DEFAULT_OUTDIR` constant
- write outputs to this directory when `--outdir` isn't supplied
- adjust CLI unit tests for new default behaviour
- update CLI step definitions to use the default folder

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_687befe84784832ba45cee188f139e94