### PR TITLE
Add CLI progress messages

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -63,16 +63,20 @@ def analyse(
 ):
     """Analyse a statement file or directory and write a summary."""
     typer.echo(f"Analysing {path}")
+    typer.echo("Reading statements...")
     transactions = load_from_path(path, verbose=verbose)
+    typer.echo(f"Loaded {len(transactions)} transactions")
 
     settings = get_settings()
     if settings.api_key:
         # use heuristics with LLM fallback when API key is available
+        typer.echo(f"Classifying with {settings.llm_provider} LLM...")
         recs = recommendation.recommend_transactions(
             transactions, provider=settings.llm_provider
         )
     else:
         # fall back to heuristics only
+        typer.echo("Classifying using heuristics...")
         labels = heuristics.classify_transactions(transactions)
         kb = recommendation.load_knowledge_base()
         recs: list[recommendation.Recommendation] = []
@@ -85,6 +89,7 @@ def analyse(
                 info = None
             recs.append(recommendation.Recommendation(tx, label, action, info))
 
+    typer.echo("Writing results...")
     outdir_path = Path(outdir) if outdir else DEFAULT_OUTDIR
     outdir_path.mkdir(parents=True, exist_ok=True)
 

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -68,3 +68,10 @@ Feature: Command-line interface
     When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with verbose output
     Then the exit code is 0
     And the terminal output contains "22b583f5-4060-44eb-a844-945cd612353c (1).pdf"
+
+  Scenario: Progress messages are displayed
+    When I run the bankcleanr analyse command with "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" with terminal output
+    Then the exit code is 0
+    And the terminal output contains "Loaded"
+    And the terminal output contains "Classifying"
+    And the terminal output contains "Analysis complete"


### PR DESCRIPTION
## Summary
- display progress updates when running the `analyse` command
- add BDD scenario to confirm progress messages

## Testing
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_687cd24bb990832b8c28f0b8f6a4415a