### PR TITLE
Fix API key placeholder handling

### DIFF
--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -159,7 +159,8 @@ def terminal_output_shows_savings(context):
 @given("an API key is configured")
 def api_key_configured(context):
     context._orig_key = os.getenv("OPENAI_API_KEY")
-    os.environ["OPENAI_API_KEY"] = "dummy"
+    if context._orig_key is None or context._orig_key.lower() == "dummy":
+        os.environ["OPENAI_API_KEY"] = "dummy"
 
 
 @then(r'the summary actions include "(?P<label>[^"]+)"')


### PR DESCRIPTION
## Summary
- update `api_key_configured` step to only inject a dummy key when no real key is set
- keep environment cleanup logic the same

## Testing
- `poetry run behave`

------
https://chatgpt.com/codex/tasks/task_e_687d0118753c832bb94b4defbc503fcb