### PR TITLE
Add non-interactive mode and PDF tweaks

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -1,0 +1,81 @@
+# Module Guide
+
+This document summarises the purpose of each Python module in the project and illustrates how they interact.
+
+## Package Structure
+
+- **bankcleanr/** – main library package
+  - `cli.py` – Typer-based command line interface for analysing statements.
+  - `analytics.py` – helper functions calculating savings totals.
+  - `io/` – PDF parsing utilities and loaders.
+  - `llm/` – language model adapters and helper functions.
+  - `recommendation.py` – generates cancellation recommendations.
+  - `reports/` – writers for CSV/PDF/terminal summaries.
+  - `rules/` – regex heuristics and prompt templates.
+  - `transaction.py` – dataclass representing a bank transaction.
+  - `settings.py` – loads configuration from `~/.bankcleanr/config.yml`.
+  - `gui/` – placeholder for a future graphical interface.
+  - `__main__.py` – entry point so the package can be executed with `python -m bankcleanr`.
+
+## Module Responsibilities
+
+### `cli`
+Implements the `bankcleanr` command with subcommands:
+- `analyse` – parse statement PDFs, classify transactions and write reports.
+- `config` – display the settings file in use.
+- `gui` – stub for a graphical interface.
+The CLI uses functions from `io.loader`, `llm`, `recommendation` and `reports.writer`.
+
+### `analytics`
+Provides pure functions to summarise recommendations:
+- `calculate_savings` sums cancelable amounts.
+- `totals_by_type` aggregates spending by category.
+- `summarize_by_description` groups transactions by description.
+
+### `io.loader`
+Dispatches to the appropriate parser based on file extension and can handle entire directories of PDFs. Uses `io.pdf.generic` for PDF parsing.
+
+### `io.pdf.*`
+- `generic` – parses generic bank statements using `pdfplumber` with regex fallbacks and optional OCR via `ocr_fallback`.
+- `barclays` / `lloyds` – thin wrappers that currently delegate to `generic`.
+- `ocr_fallback` – uses Tesseract OCR when text extraction fails.
+
+### `llm`
+Defines adapters for different language model providers (`openai`, `anthropic`, `mistral`, `gemini`, `bfl`, `local_ollama`). `classify_transactions` combines local heuristics with an adapter to label transactions. `utils.probe_adapter` performs a health check for live adapters.
+
+### `recommendation`
+Loads a cancellation knowledge base and turns labelled transactions into `Recommendation` objects with actions such as “Cancel” or “Investigate”.
+
+### `reports.writer`
+Outputs summaries in CSV, terminal text or PDF format. PDF reports include transaction tables, a “How to cancel” appendix, summary figures and the global disclaimer from `reports.disclaimers`.
+
+### `rules`
+- `regex` – loads and matches regex patterns for local classification.
+- `heuristics` – high level logic for applying and learning new patterns.
+- `prompts` – Jinja templates used by LLM adapters.
+
+### `transaction`
+Defines the `Transaction` dataclass and utilities for masking account and sort code details before sending text to LLM services.
+
+### `settings`
+Reads configuration, combines it with environment variables and exposes a `Settings` dataclass.
+
+## Flowchart
+
+```mermaid
+flowchart TD
+    A[CLI analyse] --> B(load_from_path)
+    B --> C[parse_pdf]
+    C --> D[Transaction objects]
+    D --> E[classify_transactions]
+    E --> F[heuristics.classify]
+    F -->|unknown| G[get_adapter]
+    G --> H[LLM adapter]
+    H --> I[LLM labels]
+    I --> J[heuristics.learn_new_patterns]
+    J --> K[recommend_transactions]
+    K --> L[write_summary/write_pdf_summary]
+```
+
+The CLI orchestrates the workflow: it loads transactions from PDFs, classifies them using heuristics and (optionally) an LLM adapter, updates regex rules, converts labels into recommendations, and finally writes CSV/PDF/terminal reports.
+

--- a/bankcleanr/reports/writer.py
+++ b/bankcleanr/reports/writer.py
@@ -85,6 +85,7 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
     path = Path(output)
     doc = SimpleDocTemplate(str(path), pagesize=letter)
     styles = getSampleStyleSheet()
+    styles["Normal"].fontSize = 8
     wrap_style = styles["Normal"].clone("wrapped")
     wrap_style.wordWrap = "CJK"
 
@@ -124,15 +125,15 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
     elements = [Paragraph("Transactions", styles["Heading2"])]
 
     col_widths = [
-        doc.width * 0.1,  # date
-        doc.width * 0.5,  # description
+        doc.width * 0.08,  # date
+        doc.width * 0.4,   # description
         doc.width * 0.07,  # amount
         doc.width * 0.07,  # balance
-        doc.width * 0.08,  # category
-        doc.width * 0.05,  # action
-        doc.width * 0.05,  # url
-        doc.width * 0.04,  # email
-        doc.width * 0.04,  # phone
+        doc.width * 0.12,  # category
+        doc.width * 0.08,  # action
+        doc.width * 0.08,  # url
+        doc.width * 0.05,  # email
+        doc.width * 0.05,  # phone
     ]
 
     # Create the table with column widths calibrated to the page width
@@ -142,6 +143,7 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
             [
                 ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
                 ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
             ]
         )
     )
@@ -157,6 +159,7 @@ def write_pdf_summary(transactions: Iterable, output: str, categories: Iterable[
             [
                 ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
                 ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
             ]
         )
     )

--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -2,6 +2,7 @@
 
 from typing import Iterable, List, Callable, Optional, Tuple
 import sys
+import os
 from collections import OrderedDict
 
 from bankcleanr.transaction import Transaction, normalise
@@ -39,13 +40,17 @@ def learn_new_patterns(
 ) -> None:
     """Ask to store new regex patterns derived from LLM labels."""
     if confirm is None:
+        env_resp = os.getenv("BANKCLEANR_AUTO_CONFIRM")
+
         def confirm(prompt: str) -> str:
+            if env_resp is not None:
+                return env_resp
             if not sys.stdin.isatty():
-                return "n"
+                return ""
             try:
                 return input(prompt)
             except (EOFError, OSError):
-                return "n"
+                return ""
 
     groups = group_unmatched_transactions(transactions, labels)
     if groups:

--- a/features/environment.py
+++ b/features/environment.py
@@ -4,6 +4,11 @@ from bankcleanr.rules import regex
 
 ORIG_HEURISTICS = (regex.DATA_DIR / "heuristics.yml").read_text()
 
+
+def before_scenario(context, scenario):
+    context._orig_auto_confirm = os.getenv("BANKCLEANR_AUTO_CONFIRM")
+    os.environ["BANKCLEANR_AUTO_CONFIRM"] = ""
+
 def after_scenario(context, scenario):
     if "_orig_key" in context.__dict__:
         if context._orig_key is None:
@@ -24,3 +29,9 @@ def after_scenario(context, scenario):
         delattr(context, "heuristics_path")
         if hasattr(context, "orig_heuristics"):
             delattr(context, "orig_heuristics")
+    if hasattr(context, "_orig_auto_confirm"):
+        if context._orig_auto_confirm is None:
+            os.environ.pop("BANKCLEANR_AUTO_CONFIRM", None)
+        else:
+            os.environ["BANKCLEANR_AUTO_CONFIRM"] = context._orig_auto_confirm
+        delattr(context, "_orig_auto_confirm")

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -63,6 +63,18 @@ def test_learn_new_patterns_prompts_once(monkeypatch):
     assert added == [("coffee", "Coffee shop")]
 
 
+def test_learn_new_patterns_env(monkeypatch):
+    monkeypatch.setattr(regex, "classify", lambda d: "unknown")
+    monkeypatch.setattr(regex, "add_pattern", lambda l, p: (_ for _ in ()).throw(RuntimeError("should not add")))
+    monkeypatch.setattr(regex, "reload_patterns", lambda: None)
+    monkeypatch.setenv("BANKCLEANR_AUTO_CONFIRM", "")
+
+    txs = [Transaction(date="2024-01-01", description="Coffee shop", amount="-1")]
+    labels = ["coffee"]
+
+    heuristics.learn_new_patterns(txs, labels)
+
+
 def test_group_unmatched_transactions(monkeypatch):
     monkeypatch.setattr(regex, "classify", lambda d: "unknown")
 


### PR DESCRIPTION
## Summary
- allow skipping prompt questions with `BANKCLEANR_AUTO_CONFIRM`
- preserve env var during BDD scenarios
- shrink PDF table font and adjust column widths
- add unit test for env based confirmation
- document module responsibilities

## Testing
- `poetry run pytest -q`
- `poetry run behave -q` *(fails: behave not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d1bfbfd14832bb9357bf16e1442d1