### PR TITLE
Implement mask_sensitive_fields

### DIFF
--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Dict, Type, Callable
 import logging
 
 from bankcleanr.settings import get_settings
-from bankcleanr.transaction import normalise, Transaction, mask_transaction
+from bankcleanr.transaction import normalise, Transaction, mask_sensitive_fields
 from bankcleanr.rules import heuristics
 
 from .base import AbstractAdapter
@@ -60,7 +60,7 @@ def classify_transactions(
             provider or get_settings().llm_provider,
         )
         adapter = get_adapter(provider)
-        masked = [mask_transaction(tx) for tx in unmatched]
+        masked = [mask_sensitive_fields(tx) for tx in unmatched]
         logger.debug(
             "[classify_transactions] masked: %s",
             [tx.description for tx in masked],

--- a/bankcleanr/transaction.py
+++ b/bankcleanr/transaction.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, asdict, is_dataclass
 from typing import Mapping, Any
+import warnings
 import re
 
 @dataclass
@@ -61,6 +62,17 @@ def mask_account_and_sort_codes(text: str) -> str:
 
 def mask_transaction(tx: 'Transaction') -> 'Transaction':
     """Return a copy of *tx* with sensitive fields masked."""
+
+    warnings.warn(
+        "mask_transaction is deprecated; use mask_sensitive_fields instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return mask_sensitive_fields(tx)
+
+
+def mask_sensitive_fields(tx: 'Transaction') -> 'Transaction':
+    """Return a copy of *tx* with account and sort code numbers masked."""
 
     tx = normalise(tx)
     return Transaction(

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,4 +1,9 @@
-from bankcleanr.transaction import Transaction, mask_transaction, mask_account_and_sort_codes
+from bankcleanr.transaction import (
+    Transaction,
+    mask_sensitive_fields,
+    mask_account_and_sort_codes,
+    mask_transaction,
+)
 
 
 def test_mask_account_and_sort_codes():
@@ -6,9 +11,15 @@ def test_mask_account_and_sort_codes():
     assert mask_account_and_sort_codes(text) == "Transfer to ****3456 ****5678"
 
 
-def test_mask_transaction_does_not_modify_original():
+def test_mask_sensitive_fields_does_not_modify_original():
     tx = Transaction(date="2024-01-01", description="Pay 12-34-56 12345678", amount="-1.00")
-    masked = mask_transaction(tx)
+    masked = mask_sensitive_fields(tx)
     assert masked.description == "Pay ****3456 ****5678"
     # original untouched
     assert tx.description == "Pay 12-34-56 12345678"
+
+
+def test_mask_transaction_deprecated_alias():
+    tx = Transaction(date="2024-01-01", description="Pay 12-34-56 12345678", amount="-1.00")
+    masked = mask_transaction(tx)
+    assert masked.description == "Pay ****3456 ****5678"


### PR DESCRIPTION
## Summary
- add new mask_sensitive_fields helper with deprecation wrapper
- update LLM module to use new masking helper
- cover new function with unit tests

## Testing
- `poetry run pytest -q`
- `poetry run behave -q`
- `poetry run ruff check .` *(fails: F401, E741, E401)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed280304832b80907c63cc6f705f