### PR TITLE
Fix build script error handling

### DIFF
--- a/features/steps/build_steps.py
+++ b/features/steps/build_steps.py
@@ -2,6 +2,7 @@ from behave import when, then
 from pathlib import Path
 import subprocess
 import shutil
+import os
 
 @when("I run the build script")
 def run_build_script(context):
@@ -10,12 +11,14 @@ def run_build_script(context):
     context.build_dir = root / "dist" / "linux"
     if context.build_dir.exists():
         shutil.rmtree(context.build_dir)
+    env = os.environ.copy()
+    env["TARGETS"] = "linux"
     context.build_result = subprocess.run([
         "poetry",
         "run",
         "bash",
         str(script),
-    ], cwd=root, capture_output=True)
+    ], cwd=root, capture_output=True, env=env)
 
 @then("the build succeeds")
 def build_succeeds(context):

--- a/scripts/build_exe.sh
+++ b/scripts/build_exe.sh
@@ -14,12 +14,12 @@ build_linux() {
 
 build_macos() {
   pyinstaller --clean --onefile -n "$APP" -p . bankcleanr/__main__.py \
-    --distpath "$OUTDIR/macos" --target-arch universal2 || true
+    --distpath "$OUTDIR/macos" --target-arch universal2
 }
 
 build_windows() {
   pyinstaller --clean --onefile -n "$APP.exe" -p . bankcleanr/__main__.py \
-    --distpath "$OUTDIR/windows" --windowed || true
+    --distpath "$OUTDIR/windows" --windowed
 }
 
 for t in $TARGETS; do


### PR DESCRIPTION
## Summary
- stop ignoring PyInstaller failures in build_exe.sh
- run build script only for linux during tests

## Testing
- `pytest -q`
- `behave -q`

------
https://chatgpt.com/codex/tasks/task_e_688542ebc968832b8552ef2497fc458a