### PR TITLE
Allow configurable macOS build arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ Windows. Install `pyinstaller` first (either via `pip install pyinstaller` or
 execute the script on the operating system you want to target. The resulting
 files are written to the `dist/` directory.
 
+For macOS builds the architecture can be customised by setting the
+`MACOS_ARCH` environment variable (defaults to `universal2`). For example to
+produce an ARM64-only binary run:
+
+```bash
+MACOS_ARCH=arm64 poetry run bash scripts/build_exe.sh --target macos
+```
+
+Ensure your Python interpreter matches the requested architecture. A universal
+Python can be checked with:
+
+```bash
+file $(pyenv which python3)
+```
+The output should mention both `arm64` and `x86_64` when using
+`MACOS_ARCH=universal2`.
+
 To verify a build you can run the Linux binary on the included sample PDF:
 
 ```bash

--- a/scripts/build_exe.sh
+++ b/scripts/build_exe.sh
@@ -13,8 +13,18 @@ build_linux() {
 }
 
 build_macos() {
+  local arch="${MACOS_ARCH:-universal2}"
+  if [[ "$arch" == "universal2" ]]; then
+    local pybin
+    pybin=$(command -v python3)
+    if ! file "$pybin" | grep -q "arm64" || ! file "$pybin" | grep -q "x86_64"; then
+      echo "Error: python3 at $pybin is not a universal build" >&2
+      echo "Install the universal macOS installer from python.org or set MACOS_ARCH=arm64" >&2
+      exit 1
+    fi
+  fi
   pyinstaller --clean --onefile -n "$APP" -p . bankcleanr/__main__.py \
-    --distpath "$OUTDIR/macos" --target-arch universal2
+    --distpath "$OUTDIR/macos" --target-arch "$arch"
 }
 
 build_windows() {


### PR DESCRIPTION
## Summary
- allow scripts/build_exe.sh to set macOS arch via `MACOS_ARCH`
- add interpreter check for universal builds
- document new variable and architecture verification in README

## Testing
- `pytest -q`
- `behave -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e1a0851c832b9e10e7bba8dd5214