### PR TITLE
Add heuristic CRUD tests and BDD scenario

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,6 +78,16 @@ def add_heuristic(new_rule: NewHeuristic, user: User = Depends(get_current_user)
     return row.model_dump()
 
 
+@app.delete("/heuristics/{rule_id}")
+def delete_heuristic(rule_id: int, user: User = Depends(get_current_user), session: Session = Depends(get_session)):
+    row = session.get(Heuristic, rule_id)
+    if not row or row.user_id != user.id:
+        raise HTTPException(status_code=404, detail="not found")
+    session.delete(row)
+    session.commit()
+    return {"detail": "deleted"}
+
+
 @app.post("/classify")
 def classify(transactions: list[Transaction]):
     labels = heuristics_mod.classify_transactions(transactions)

--- a/features/api.feature
+++ b/features/api.feature
@@ -3,3 +3,9 @@ Feature: Backend API
     Given an authenticated client
     When I POST two transactions to "/upload"
     Then the summary endpoint reports 2 transactions
+
+  Scenario: Heuristic editor happy path
+    Given an authenticated client
+    When I POST two transactions to "/upload"
+    And I save a heuristic labeled "coffee" matching "coffee"
+    Then the heuristic save response confirms the rule

--- a/features/steps/api_steps.py
+++ b/features/steps/api_steps.py
@@ -52,6 +52,28 @@ def post_transactions(context):
     context.loop.run_until_complete(action())
 
 
+@when('I save a heuristic labeled "{label}" matching "{pattern}"')
+def save_heuristic(context, label, pattern):
+    context.saved_label = label
+    context.saved_pattern = pattern
+    payload = {"label": label, "pattern": pattern}
+    async def action():
+        resp = await context.client.post("/heuristics", json=payload, params={"token": context.token})
+        context.heuristic_resp = resp
+    context.loop.run_until_complete(action())
+
+
+@then('the heuristic save response confirms the rule')
+def confirm_save(context):
+    async def check():
+        resp = context.heuristic_resp
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["label"] == context.saved_label
+        assert data["pattern"] == context.saved_pattern
+    context.loop.run_until_complete(check())
+
+
 @then('the summary endpoint reports 2 transactions')
 def check_summary(context):
     async def check():


### PR DESCRIPTION
## Summary
- extend backend tests with CRUD checks for heuristics
- add delete endpoint in backend app
- add heuristic editor scenario to API feature
- implement behave steps for heuristic editor

## Testing
- `poetry install --with dev`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68866ccde260832b991dc98aa67ac922