### PR TITLE
Enable Cypress E2E tests via Docker

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,6 @@
+FROM cypress/included:13.7.3
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend .
+CMD ["npx", "cypress", "run"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ npm install
 sudo apt-get update && sudo apt-get install -y xvfb
 xvfb-run -a npm run test:e2e
 ```
+Alternatively run the tests inside Docker:
+```bash
+docker compose run --rm e2e
+```
 
 This starts Cypress in a virtual display so the browser can run in headless
 mode. Use `cypress run --browser chrome --headed` if you prefer a visible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,11 @@ services:
       - APP_ENV=prod
     ports:
       - "8000:8000"
+  e2e:
+    build:
+      context: .
+      dockerfile: Dockerfile.e2e
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    entrypoint: ["npx", "cypress", "run"]


### PR DESCRIPTION
## Summary
- add Dockerfile.e2e using cypress/included image
- add `e2e` service to docker-compose
- document docker-based test run in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868226fa5c832baf06474fc709b423