### PR TITLE
Update Cypress instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ npm install
 sudo apt-get update && sudo apt-get install -y xvfb
 xvfb-run -a npm run test:e2e
 ```
-Alternatively run the tests inside Docker:
+Alternatively run the tests inside Docker. Ensure the Vite dev server is running
+at `http://localhost:5173` before launching the Cypress container:
 ```bash
+cd frontend
+npm run dev &
 docker compose run --rm e2e
 ```
 


### PR DESCRIPTION
## Summary
- clarify that the Vite dev server should be running before starting Cypress
- show the `npm run dev` step when launching the Cypress container

## Testing
- `make test` *(fails: 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6886a5206a84832b8bce08a7dd9ecb8a