### PR TITLE
Enable Vite dev server container

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,10 @@ npm install
 sudo apt-get update && sudo apt-get install -y xvfb
 xvfb-run -a npm run test:e2e
 ```
-Alternatively run the tests inside Docker. Ensure the Vite dev server is running
-at `http://localhost:5173` before launching the Cypress container:
+Alternatively run everything inside Docker. Start the Vite dev server and Cypress
+with a single command:
 ```bash
-cd frontend
-npm run dev &
-docker compose run --rm e2e
+docker compose up frontend e2e
 ```
 
 This starts Cypress in a virtual display so the browser can run in headless

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,14 @@ services:
       - APP_ENV=prod
     ports:
       - "8000:8000"
+  frontend:
+    image: node:20
+    working_dir: /app
+    command: npm run dev
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "5173:5173"
   e2e:
     build:
       context: .

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:5173',
+    baseUrl: 'http://frontend:5173',
     supportFile: false,
   },
 });


### PR DESCRIPTION
## Summary
- add a `frontend` service running `npm run dev`
- point Cypress at the `frontend` container
- document starting both services via `docker compose`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6886abcbdd4c832b9d550c48c800712f