### PR TITLE
Fix compose frontend command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   frontend:
     image: node:20
     working_dir: /app
-    command: npm run dev
+    command: sh -c "npm ci && npm run dev -- --host"
     volumes:
       - ./frontend:/app
     ports:


### PR DESCRIPTION
## Summary
- ensure frontend container installs dependencies before starting and binds to all interfaces

## Testing
- `podman compose up frontend e2e` *(fails: short-name "cypress/included:13.7.3" did not resolve to an alias)*
- `make test` *(fails: build feature aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68872a14dfb8832ba7c964eda9c997de