### PR TITLE
fix e2e container volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ with a single command:
 ```bash
 docker compose up frontend e2e
 ```
+The `e2e` service now runs entirely inside the container and no longer mounts the
+`frontend` directory from the host.
 
 This starts Cypress in a virtual display so the browser can run in headless
 mode. Use `cypress run --browser chrome --headed` if you prefer a visible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,4 @@ services:
       context: .
       dockerfile: Dockerfile.e2e
     working_dir: /app
-    volumes:
-      - ./frontend:/app
     entrypoint: ["npx", "cypress", "run"]


### PR DESCRIPTION
## Summary
- remove frontend mount from e2e container
- clarify README that e2e service no longer mounts host directory

## Testing
- `poetry install --with dev`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68873c0cb128832b9a1ec13ccf357f07