### PR TITLE
Add frontend healthcheck and e2e dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,17 @@ services:
       - ./frontend:/app
     ports:
       - "5173:5173"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
   e2e:
     build:
       context: .
       dockerfile: Dockerfile.e2e
     working_dir: /app
     entrypoint: ["npx", "cypress", "run"]
+    depends_on:
+      frontend:
+        condition: service_healthy


### PR DESCRIPTION
## Summary
- add a curl-based healthcheck for the frontend
- wait for frontend health before starting the e2e service

## Testing
- `poetry run pytest tests/test_backend_app.py`
- `podman compose up frontend e2e` *(fails: short-name "cypress/included:13.7.3" did not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6887701f5c90832b978472fe4459c301