### PR TITLE
Add e2e make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit behave component lint
+.PHONY: install test unit behave component lint e2e
 
 install:
 	poetry install --with dev
@@ -14,4 +14,11 @@ component:
 
 test: unit component behave
 lint:
-	poetry run ruff check .
+        poetry run ruff check .
+
+e2e:
+	@if command -v podman >/dev/null 2>&1; then \
+	podman compose up --build frontend e2e; \
+	else \
+	docker compose up --build frontend e2e; \
+	fi

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Then start the Vite dev server and run the tests inside the containers:
 
 ```bash
 podman compose up --build frontend e2e
+make e2e
 ```
+The `make e2e` command automatically uses Podman when available and falls back
+to Docker otherwise.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add an `e2e` target to Makefile that calls `podman compose up --build frontend e2e` and falls back to Docker
- document the new make command in the README

## Testing
- `poetry run pytest`
- `poetry run behave --no-capture` *(fails: Build and run standalone binary - ABORTED)*

------
https://chatgpt.com/codex/tasks/task_e_688785804434832bab8ef42293d220fc