### PR TITLE
Remove obsolete compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   api:
     build: .


### PR DESCRIPTION
## Summary
- remove top-level `version:` key from `docker-compose.yml`

## Testing
- `pytest -q`
- `podman-compose -f docker-compose.yml --dry-run up`

------
https://chatgpt.com/codex/tasks/task_e_688794655c08832bb2490acd907c15be