### PR TITLE
Update README with Vite troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ make e2e
 The `make e2e` command automatically uses Podman when available and falls back
 to Docker otherwise.
 
+If the Cypress container cannot reach the dev server, Vite may be refusing
+connections from external hosts. Update `frontend/vite.config.ts` so the dev
+server listens on all interfaces:
+
+```ts
+export default defineConfig({
+  server: {
+    host: true,
+  },
+});
+```
+
 ## Configuration
 
 The tool loads settings from `~/.bankcleanr/config.yml`. Set your preferred LLM


### PR DESCRIPTION
## Summary
- document allowing external hosts in Vite when running frontend in containers

## Testing
- `make test` *(fails: no tests were collected)*

------
https://chatgpt.com/codex/tasks/task_e_6888b0446b84832bb78559aeee14d413