### PR TITLE
Update dev server host handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ docker compose up frontend e2e
 The `e2e` service now runs entirely inside the container and no longer mounts the
 `frontend` directory from the host.
 
+When running the dev server inside Docker or a CI environment set the
+`CI` variable so Vite only allows requests from the `frontend` hostname:
+
+```bash
+CI=1 npm run dev
+```
+Local development does not require this variable.
+
 This starts Cypress in a virtual display so the browser can run in headless
 mode. Use `cypress run --browser chrome --headed` if you prefer a visible
 browser.
@@ -103,12 +111,15 @@ to Docker otherwise.
 
 If the Cypress container cannot reach the dev server, Vite may be refusing
 connections from external hosts. Update `frontend/vite.config.ts` so the dev
-server listens on all interfaces:
+server listens on all interfaces and set the `CI` variable when running in
+containers:
 
 ```ts
 export default defineConfig({
   server: {
     host: true,
+    // CI=1 restricts access to the "frontend" hostname
+    allowedHosts: process.env.CI ? ['frontend'] : ['localhost'],
   },
 });
 ```

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// CI or Docker environments set the CI/E2E flag so the dev server
+// only accepts requests from the "frontend" hostname. Local runs can
+// use localhost or disable the check.
+const inCi = process.env.CI || process.env.E2E;
+const allowedHosts = inCi ? ['frontend'] : ['localhost'];
+
 export default defineConfig({
   plugins: [react()],
   server: {
     host: true, // or '0.0.0.0'
     port: 5173,
-    allowedHosts: ['frontend'],
+    strictPort: true,
+    allowedHosts,
   }
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server with strict port and conditional `allowedHosts`
- document `CI` variable usage for running in Docker/CI environments

## Testing
- `make test`
- `npm install`
- `xvfb-run -a npm run test:e2e` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888b81ec510832b8baa474734ebe70b