### PR TITLE
Parametrize Cypress baseUrl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       context: .
       dockerfile: Dockerfile.e2e
     working_dir: /app
+    environment:
+      - CYPRESS_BASE_URL=http://frontend:5173
     entrypoint: ["npx", "cypress", "run"]
     depends_on:
       frontend:

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://frontend:5173',
+    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:5173',
     supportFile: false,
   },
 });

--- a/frontend/cypress/e2e/home.cy.ts
+++ b/frontend/cypress/e2e/home.cy.ts
@@ -1,0 +1,6 @@
+describe('home page', () => {
+  it('loads', () => {
+    cy.visit('/');
+    cy.contains('Heuristic Editor');
+  });
+});


### PR DESCRIPTION
## Summary
- allow setting Cypress baseUrl via env var
- pass base url to the e2e container
- add a basic home page test

## Testing
- `pytest -q`
- `npm run test:e2e --silent` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6888c3ca8ae8832bbbbb5a36ff825258