### PR TITLE
Fix frontend host in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ When running the dev server inside Docker or a CI environment set the
 CI=1 npm run dev
 ```
 Local development does not require this variable.
+The `docker-compose.yml` already sets `CI=1` for the `frontend` service so
+requests from the `e2e` container are allowed.
 
 This starts Cypress in a virtual display so the browser can run in headless
 mode. Use `cypress run --browser chrome --headed` if you prefer a visible

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: node:20
     working_dir: /app
     command: sh -c "npm ci && npm run dev -- --host"
+    environment:
+      - CI=1
     volumes:
       - ./frontend:/app
     ports:


### PR DESCRIPTION
## Summary
- allow Vite dev server to accept requests from e2e container
- explain in docs that docker-compose sets `CI=1`

## Testing
- `poetry run pytest tests/test_backend_app.py`
- `make e2e` *(fails: `docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6888c8525e94832b8b0ecb75c2e14007