### PR TITLE
Fix Docker build order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,23 @@
 FROM python:3.12-slim
 WORKDIR /app
+
+# Disable virtual environments so dependencies install directly into the
+# container image. Poetry also respects this environment variable during the
+# build stage.
+ENV POETRY_VIRTUALENVS_CREATE=false
+
 COPY pyproject.toml poetry.lock README.md ./
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install --only main
+# Install runtime dependencies without installing the project itself. The
+# application code is copied in a later step to keep Docker layer caching
+# effective during local development.
+RUN pip install poetry \
+    && poetry config virtualenvs.create false \
+    && poetry install --only main --no-root
+
 COPY backend ./backend
 COPY bankcleanr ./bankcleanr
+
+# Document which port the FastAPI app listens on
+EXPOSE 8000
+
 CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ docker compose up api
 ```
 
 This runs the API on [localhost:8000](http://localhost:8000) and sets the
-`APP_ENV` variable from `docker-compose.yml` (defaults to `prod`). Launch the
+`APP_ENV` variable from `docker-compose.yml` (defaults to `prod`). The Docker
+image disables Poetry's virtual environments by setting
+`POETRY_VIRTUALENVS_CREATE=false` and exposes port 8000.
+Launch the
 frontend dev server alongside it with:
 
 ```bash


### PR DESCRIPTION
## Summary
- install dependencies with `--no-root` and keep poetry out of virtualenvs
- copy the backend after installing deps
- expose port 8000
- mention the env var in the FastAPI section of the README

## Testing
- `poetry run pytest`
- `poetry run behave` *(fails: Build script scenario aborted)*
- `docker compose build api` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688a958d2fc4832bba69875318085650