### PR TITLE
Add .dockerignore to trim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+__pycache__/
+*.pyc
+.venv/
+*.log
+tests/


### PR DESCRIPTION
## Summary
- avoid sending unnecessary files when building images by adding a `.dockerignore`

## Testing
- `make test` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_688a9a9a55a4832bb2ed7cdc4dab2080