### PR TITLE
Add JSONL upload feature and test

### DIFF
--- a/frontend/cypress/e2e/heuristics.cy.ts
+++ b/frontend/cypress/e2e/heuristics.cy.ts
@@ -1,16 +1,19 @@
 describe('heuristic editor', () => {
   it('user uploads JSONL -> edits rule -> saves -> sees confirmation', () => {
-    cy.intercept('POST', '/upload', { statusCode: 200, body: { count: 1 } });
-    cy.intercept('GET', '/heuristics', { fixture: 'initial.json' });
-    cy.intercept('POST', '/heuristics', { body: { id: 1, label: 'coffee', pattern: 'coffee' } });
+    cy.intercept('POST', '/upload*', { statusCode: 200, body: { count: 1 } }).as('upload');
+    cy.intercept('GET', '/heuristics*', { fixture: 'initial.json' }).as('load');
+    cy.intercept('POST', '/heuristics*', { body: { id: 1, label: 'coffee', pattern: 'coffee' } });
 
     cy.visit('/');
+    cy.wait('@load');
 
     cy.fixture('tx.jsonl').then((content) => {
       const blob = new Blob([content], { type: 'application/jsonl' });
       const file = new File([blob], 'tx.jsonl');
       cy.get('input[type=file]').first().selectFile({ contents: file, fileName: 'tx.jsonl' });
     });
+    cy.wait('@upload');
+    cy.contains('Uploaded 1 transactions');
 
     cy.get('tbody tr').eq(0).find('input').first().clear().type('coffee');
     cy.get('tbody tr').eq(0).find('button').contains('Save').click();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,31 @@ export default function App() {
   const [rules, setRules] = useState<Rule[]>([]);
   const [message, setMessage] = useState<string>('');
 
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const lines = text.trim().split(/\r?\n/);
+    const txs = lines.map(line => JSON.parse(line));
+    setMessage('Uploading...');
+    try {
+      const resp = await fetch('/upload?token=dummy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(txs)
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setMessage(`Uploaded ${data.count} transactions`);
+      } else {
+        setMessage('Upload failed');
+      }
+    } catch {
+      setMessage('Upload failed');
+    }
+    setTimeout(() => setMessage(''), 1000);
+  };
+
   // load heuristics on mount
   useEffect(() => {
     fetch('/heuristics?token=dummy')
@@ -35,6 +60,7 @@ export default function App() {
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Heuristic Editor</h1>
+      <input type="file" accept=".jsonl" onChange={handleUpload} className="mb-2" />
       {message && <div role="alert">{message}</div>}
       <RuleTable rules={rules} onChange={handleChange} onSave={handleSave} />
     </div>


### PR DESCRIPTION
## Summary
- allow users to upload transaction JSONL files and send them to the backend
- show success/failure messages in the UI
- expand heuristic E2E test to confirm `/upload` is triggered

## Testing
- `poetry run pytest -q`
- `poetry run behave -q`
- `CYPRESS_BASE_URL=http://localhost:5173 xvfb-run -a npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_688b1ad4ccc4832bad2e82f676250b9f