### PR TITLE
Add help note for regex patterns

### DIFF
--- a/frontend/cypress/e2e/heuristics.cy.ts
+++ b/frontend/cypress/e2e/heuristics.cy.ts
@@ -6,6 +6,7 @@ describe('heuristic editor', () => {
 
     cy.visit('/');
     cy.wait('@load');
+    cy.contains('Pattern expects a regular expression');
 
     cy.fixture('tx.jsonl').then((content) => {
       const blob = new Blob([content], { type: 'application/jsonl' });

--- a/frontend/cypress/e2e/home.cy.ts
+++ b/frontend/cypress/e2e/home.cy.ts
@@ -2,5 +2,6 @@ describe('home page', () => {
   it('loads', () => {
     cy.visit('/');
     cy.contains('Heuristic Editor');
+    cy.contains('Pattern expects a regular expression');
   });
 });

--- a/frontend/src/RuleTable.tsx
+++ b/frontend/src/RuleTable.tsx
@@ -69,6 +69,17 @@ export default function RuleTable({ rules, onChange, onSave }: Props) {
         <input type="file" onChange={handleImport} />
         <button onClick={handleExport}>Export CSV</button>
       </div>
+      <p className="text-sm text-gray-600 mb-2">
+        Pattern expects a regular expression matched against transaction descriptions.
+        {' '}
+        <a
+          href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          (Regex guide)
+        </a>
+      </p>
       <table className="border-collapse w-full">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- explain that the `Pattern` field uses regex in RuleTable
- test for presence of regex help text in Cypress tests

## Testing
- `poetry run pytest`
- `poetry run behave` *(fails: Build and run standalone binary scenario aborted)*
- `npm run test:e2e` *(fails: Cypress could not verify server)*

------
https://chatgpt.com/codex/tasks/task_e_688b35a2fef0832ba6f413be0739a2a3