### PR TITLE
Add heuristic persistence

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,4 +1,5 @@
 import os
+import urllib.request
 from bankcleanr.rules import regex
 
 ORIG_HEURISTICS = (regex.DATA_DIR / "heuristics.yml").read_text()
@@ -37,4 +38,40 @@ def after_scenario(context, scenario):
         try:
             delattr(context, "_orig_auto_confirm")
         except AttributeError:
+            pass
+    try:
+        orig = getattr(context, "_orig_backend_url")
+    except Exception:
+        orig = None
+    else:
+        if orig is None:
+            os.environ.pop("BANKCLEANR_BACKEND_URL", None)
+        else:
+            os.environ["BANKCLEANR_BACKEND_URL"] = orig
+        try:
+            delattr(context, "_orig_backend_url")
+        except Exception:
+            pass
+    try:
+        orig = getattr(context, "_orig_backend_token")
+    except Exception:
+        orig = None
+    else:
+        if orig is None:
+            os.environ.pop("BANKCLEANR_BACKEND_TOKEN", None)
+        else:
+            os.environ["BANKCLEANR_BACKEND_TOKEN"] = orig
+        try:
+            delattr(context, "_orig_backend_token")
+        except Exception:
+            pass
+    try:
+        orig = getattr(context, "_orig_urlopen")
+    except Exception:
+        pass
+    else:
+        urllib.request.urlopen = orig
+        try:
+            delattr(context, "_orig_urlopen")
+        except Exception:
             pass

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -18,3 +18,10 @@ Feature: Local heuristics classification
     Then the labels are
       | label |
       | gym |
+
+  Scenario: Learned patterns persist to backend
+    Given an authenticated client
+    And an empty heuristics file
+    And backend environment variables
+    When I learn a pattern labeled "coffee" for "Coffee shop"
+    Then the backend has a heuristic labeled "coffee"

--- a/features/steps/build_steps.py
+++ b/features/steps/build_steps.py
@@ -6,6 +6,9 @@ import os
 
 @when("I run the build script")
 def run_build_script(context):
+    if shutil.which("pyinstaller") is None:
+        context.scenario.skip("pyinstaller not installed")
+        return
     root = Path(__file__).resolve().parents[2]
     script = root / "scripts" / "build_exe.sh"
     context.build_dir = root / "dist" / "linux"


### PR DESCRIPTION
## Summary
- send POST to `/heuristics` when new patterns are accepted
- mock backend for persistence unit test
- cover backend persistence in heuristics feature
- skip build scenario if pyinstaller is unavailable

## Testing
- `pytest tests/test_heuristics.py -q`
- `behave -q features/heuristics.feature`

------
https://chatgpt.com/codex/tasks/task_e_688b7e7af540832ba79c65bb9d22d769