### PR TITLE
Switch heuristics to SQLite

### DIFF
--- a/bankcleanr/rules/db_store.py
+++ b/bankcleanr/rules/db_store.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+from typing import Dict
+
+from sqlmodel import SQLModel, create_engine, Session, select
+
+from backend.models import Heuristic
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+HEURISTICS_PATH = DATA_DIR / "heuristics.yml"
+
+ENV = os.getenv("APP_ENV", "dev")
+DB_PATH = Path(f"data-{ENV}.db")
+engine = create_engine(f"sqlite:///{DB_PATH}", echo=False)
+
+
+def init_db() -> None:
+    """Create tables if they don't exist."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    """Return a new DB session bound to the engine."""
+    return Session(engine)
+
+
+def _seed_from_yaml(session: Session) -> None:
+    if session.exec(select(Heuristic)).first() is None and HEURISTICS_PATH.exists():
+        import yaml
+
+        data = yaml.safe_load(HEURISTICS_PATH.read_text()) or {}
+        for label, pattern in data.items():
+            row = Heuristic(user_id=0, label=label, pattern=pattern)
+            session.add(row)
+        session.commit()
+
+
+def get_patterns() -> Dict[str, str]:
+    """Return label->pattern mappings from the database."""
+    init_db()
+    with get_session() as session:
+        _seed_from_yaml(session)
+        rows = session.exec(select(Heuristic)).all()
+        return {r.label: r.pattern for r in rows}
+
+
+def add_pattern(label: str, pattern: str) -> None:
+    """Store a new heuristic pattern in the database."""
+    init_db()
+    with get_session() as session:
+        row = Heuristic(user_id=0, label=label, pattern=pattern)
+        session.add(row)
+        session.commit()

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -9,8 +9,8 @@ Feature: Local heuristics classification
       | dropbox |
       | unknown |
 
-  Scenario: Load patterns from YAML
-    Given a heuristics file containing
+  Scenario: Load patterns from database
+    Given a heuristics database containing
       | label | pattern |
       | gym   | gym membership |
     And a transaction "Monthly gym membership"
@@ -21,7 +21,7 @@ Feature: Local heuristics classification
 
   Scenario: Learned patterns persist to backend
     Given an authenticated client
-    And an empty heuristics file
+    And an empty heuristics database
     And backend environment variables
     When I learn a pattern labeled "coffee" for "Coffee shop"
     Then the backend has a heuristic labeled "coffee"

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -29,7 +29,7 @@ Feature: LLM classification
     Then no more than 5 concurrent requests were sent
 
   Scenario: Learned patterns are applied immediately
-    Given an empty heuristics file
+    Given an empty heuristics database
     And a transaction "Coffee shop"
     And the OpenAI adapter is mocked to return "coffee"
     When I classify transactions with the LLM accepting new patterns
@@ -38,7 +38,7 @@ Feature: LLM classification
       | coffee |
 
   Scenario: Summary of new pattern suggestions is shown once
-    Given an empty heuristics file
+    Given an empty heuristics database
     And duplicate transactions requiring LLM
     And the OpenAI adapter is mocked to return "coffee"
     When I classify transactions with the LLM summarising new patterns


### PR DESCRIPTION
## Summary
- query heuristics using SQLModel via new `db_store` module
- reload regex patterns from the database
- seed DB with existing YAML heuristics when empty
- update tests and BDD features to use temporary DB

## Testing
- `pytest tests/test_heuristics.py tests/test_backend_app.py -q`
- `behave -q features/heuristics.feature features/api.feature`

------
https://chatgpt.com/codex/tasks/task_e_688b8b3b3cb8832b9431d6b98dae7f40