### PR TITLE
Seed heuristics from yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ docker compose up frontend
 The Vite dev server will then be available on port 5173 while the API continues
 to listen on port 8000.
 
+When starting with an empty database run the import script once to seed the
+default heuristics:
+
+```bash
+poetry run python scripts/import_heuristics.py
+```
+
 ### Updating heuristics
 
 Regex patterns for the local classifier live in `bankcleanr/data/heuristics.yml`.

--- a/features/heuristics.feature
+++ b/features/heuristics.feature
@@ -25,3 +25,8 @@ Feature: Local heuristics classification
     And backend environment variables
     When I learn a pattern labeled "coffee" for "Coffee shop"
     Then the backend has a heuristic labeled "coffee"
+
+  Scenario: Import heuristics file
+    Given a fresh heuristics database
+    When I run the import heuristics script
+    Then the database has a heuristic labeled "spotify"

--- a/scripts/import_heuristics.py
+++ b/scripts/import_heuristics.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Seed the heuristics database from the default YAML file."""
+
+from bankcleanr.rules import db_store
+from backend.models import Heuristic
+import yaml
+
+
+def main() -> None:
+    """Load patterns from heuristics.yml into the database."""
+    db_store.init_db()
+    data = yaml.safe_load(db_store.HEURISTICS_PATH.read_text()) or {}
+    with db_store.get_session() as session:
+        for label, pattern in data.items():
+            row = Heuristic(user_id=0, label=label, pattern=pattern)
+            session.add(row)
+        session.commit()
+    print(f"Imported {len(data)} heuristics")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_script.py
+++ b/tests/test_import_script.py
@@ -1,0 +1,27 @@
+import importlib
+import runpy
+from pathlib import Path
+
+from sqlmodel import create_engine, Session, select
+
+from backend.models import Heuristic
+
+
+def test_import_script_loads_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    db_file = tmp_path / "rules.db"
+
+    from bankcleanr.rules import db_store
+
+    importlib.reload(db_store)
+    db_store.DB_PATH = db_file
+    db_store.engine = create_engine(f"sqlite:///{db_file}", echo=False)
+    db_store.init_db()
+
+    root = Path(__file__).resolve().parents[1]
+    runpy.run_path(str(root / "scripts" / "import_heuristics.py"), run_name="__main__")
+
+    with Session(db_store.engine) as session:
+        labels = [h.label for h in session.exec(select(Heuristic)).all()]
+
+    assert "spotify" in labels


### PR DESCRIPTION
## Summary
- add a helper script to import heuristics from `bankcleanr/data/heuristics.yml`
- document seeding the DB with the new script
- test the import script with pytest
- cover the behaviour in a new BDD scenario

## Testing
- `poetry run pytest`
- `poetry run behave -q features/heuristics.feature`


------
https://chatgpt.com/codex/tasks/task_e_688be9c38240832b9b2dfc63be3e0c55