### PR TITLE
Refactor prompt and adapters for new rule output

### DIFF
--- a/bankcleanr/llm/local_ollama.py
+++ b/bankcleanr/llm/local_ollama.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import requests
 
 from .base import AbstractAdapter
-from .utils import load_heuristics_text
+from .utils import load_heuristics_texts
 from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
@@ -20,24 +20,23 @@ class LocalOllamaAdapter(AbstractAdapter):
         model: str = "llama3",
         host: str = "http://localhost:11434",
         api_key: str | None = None,
-        cancellation_path: Path = DATA_DIR / "cancellation.yml",
     ):
         self.model = model
         self.host = host.rstrip("/")
         self.api_key = api_key
-        self.heuristics_text = load_heuristics_text()
-        self.cancellation_text = (
-            cancellation_path.read_text() if cancellation_path.exists() else ""
-        )
+        (
+            self.user_heuristics_text,
+            self.global_heuristics_text,
+        ) = load_heuristics_texts()
 
     def classify_transactions(self, transactions: Iterable) -> List[str]:
         tx_objs = [normalise(tx) for tx in transactions]
         labels: List[str] = []
         for tx in tx_objs:
             prompt = CATEGORY_PROMPT.render(
-                description=tx.description,
-                heuristics=self.heuristics_text,
-                cancellation=self.cancellation_text,
+                txn=tx,
+                user_heuristics=self.user_heuristics_text,
+                global_heuristics=self.global_heuristics_text,
             )
             try:
                 resp = requests.post(

--- a/bankcleanr/llm/utils.py
+++ b/bankcleanr/llm/utils.py
@@ -7,6 +7,14 @@ from .base import AbstractAdapter
 from bankcleanr.rules import db_store
 
 
+def load_heuristics_texts() -> tuple[str, str]:
+    """Return user and global heuristics as newline separated lines."""
+    user, global_ = db_store.get_user_and_global_patterns()
+    user_text = "\n".join(f"{label}: {pattern}" for label, pattern in user.items())
+    global_text = "\n".join(f"{label}: {pattern}" for label, pattern in global_.items())
+    return user_text, global_text
+
+
 def load_heuristics_text() -> str:
     """Return heuristics as newline separated "label: pattern" lines."""
     patterns = db_store.get_patterns()

--- a/bankcleanr/rules/db_store.py
+++ b/bankcleanr/rules/db_store.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 from sqlmodel import SQLModel, create_engine, Session, select
 
@@ -51,3 +51,19 @@ def add_pattern(label: str, pattern: str) -> None:
         row = Heuristic(user_id=0, label=label, pattern=pattern)
         session.add(row)
         session.commit()
+
+
+def get_user_and_global_patterns() -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Return separate mappings for user and global heuristics."""
+    init_db()
+    with get_session() as session:
+        _seed_from_yaml(session)
+        rows = session.exec(select(Heuristic)).all()
+        user_patterns: Dict[str, str] = {}
+        global_patterns: Dict[str, str] = {}
+        for r in rows:
+            if r.user_id == 0:
+                global_patterns[r.label] = r.pattern
+            else:
+                user_patterns[r.label] = r.pattern
+        return user_patterns, global_patterns

--- a/bankcleanr/rules/prompts.py
+++ b/bankcleanr/rules/prompts.py
@@ -1,20 +1,20 @@
 from jinja2 import Template
 
+
 CATEGORY_PROMPT = Template(
     """
-    Classify the following transaction description and respond with JSON.
+    Classify the transaction below and respond with JSON.
 
-    Required keys:
-      "category"            - short label for the merchant
-      "reasons_to_cancel"   - list explaining why a user might cancel
-      "checklist"           - step-by-step cancellation checklist
+    Keys:
+      "category" - short label for the merchant
+      "new_rule" - optional regex pattern to recognise similar transactions
 
-    Known heuristics (label: pattern):
-    {{ heuristics }}
+    User heuristics (label: pattern):
+    {{ user_heuristics }}
 
-    Known cancellation paths:
-    {{ cancellation }}
+    Global heuristics (label: pattern):
+    {{ global_heuristics }}
 
-    Transaction: {{ description }}
+    Transaction: {{ txn.description }}
     """
 )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,16 @@
+import types
+from bankcleanr.rules.prompts import CATEGORY_PROMPT
+
+
+def test_category_prompt_render():
+    txn = types.SimpleNamespace(description="Spotify subscription")
+    rendered = CATEGORY_PROMPT.render(
+        txn=txn,
+        user_heuristics="coffee: COFFEE",
+        global_heuristics="spotify: SPOTIFY",
+    )
+    assert "Spotify subscription" in rendered
+    assert "coffee: COFFEE" in rendered
+    assert "spotify: SPOTIFY" in rendered
+    assert "\"category\"" in rendered
+    assert "\"new_rule\"" in rendered


### PR DESCRIPTION
## Summary
- prompt template now uses txn description, user and global heuristics
- LLM adapters pass new template inputs and parse optional new_rule
- add unit test for CATEGORY_PROMPT rendering and update OpenAI adapter tests

## Testing
- `pytest tests/test_prompts.py tests/test_openai_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688de010d900832bbf332733f8e94dc5