### PR TITLE
feat: add heuristics manager

### DIFF
--- a/bankcleanr/recommendation.py
+++ b/bankcleanr/recommendation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Dict, Callable
+from typing import Iterable, List, Dict
 
 import yaml
 
@@ -34,11 +34,10 @@ def recommend_transactions(
     transactions: Iterable,
     provider: str | None = None,
     kb_path: Path = KB_PATH,
-    confirm: Callable[[str], str] | None = None,
 ) -> List[Recommendation]:
     """Return recommendations for each transaction."""
     txs = [normalise(tx) for tx in transactions]
-    labels = classify_transactions(txs, provider=provider, confirm=confirm)
+    labels = classify_transactions(txs, provider=provider)
     kb = load_knowledge_base(kb_path)
     results: List[Recommendation] = []
     for tx, label in zip(txs, labels):

--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -1,13 +1,8 @@
 """Local heuristics for quick transaction classification."""
 
-from typing import Iterable, List, Callable, Optional, Tuple
-import sys
-import os
-import json
-import urllib.request
-from collections import OrderedDict
+from typing import Iterable, List
 
-from bankcleanr.transaction import Transaction, normalise
+from bankcleanr.transaction import normalise
 from . import regex
 
 
@@ -18,69 +13,3 @@ def classify_transactions(transactions: Iterable) -> List[str]:
         tx_obj = normalise(tx)
         labels.append(regex.classify(tx_obj.description))
     return labels
-
-
-def group_unmatched_transactions(
-    transactions: Iterable[Transaction],
-    labels: Iterable[str],
-) -> List[Tuple[str, str, int]]:
-    """Return unmatched transactions grouped by description with counts."""
-    counts: OrderedDict[Tuple[str, str], int] = OrderedDict()
-    for tx, label in zip(transactions, labels):
-        if label == "unknown":
-            continue
-        if regex.classify(tx.description) == "unknown":
-            key = (label, tx.description)
-            counts[key] = counts.get(key, 0) + 1
-    return [(label, desc, count) for (label, desc), count in counts.items()]
-
-
-def learn_new_patterns(
-    transactions: Iterable[Transaction],
-    labels: Iterable[str],
-    confirm: Optional[Callable[[str], str]] = None,
-) -> None:
-    """Ask to store new regex patterns derived from LLM labels."""
-    if confirm is None:
-        env_resp = os.getenv("BANKCLEANR_AUTO_CONFIRM")
-
-        def confirm(prompt: str) -> str:
-            if env_resp is not None:
-                return env_resp
-            if not sys.stdin.isatty():
-                return ""
-            try:
-                return input(prompt)
-            except (EOFError, OSError):
-                return ""
-
-    groups = group_unmatched_transactions(transactions, labels)
-    if groups:
-        print("Unmatched transaction summary:")
-        for label, description, count in groups:
-            suffix = f" ({count})" if count > 1 else ""
-            print(f"- {description}{suffix} -> {label}")
-
-    for label, description, _ in groups:
-        prompt = f"Add pattern for '{label}' matching '{description}'? [y/N] "
-        answer = confirm(prompt)
-        if answer and answer.lower().startswith("y"):
-            regex.add_pattern(label, description)
-            regex.reload_patterns()
-            backend_url = os.getenv("BANKCLEANR_BACKEND_URL")
-            token = os.getenv("BANKCLEANR_BACKEND_TOKEN")
-            if backend_url and token:
-                dest = f"{backend_url.rstrip('/')}/heuristics?token={token}"
-                payload = json.dumps({"label": label, "pattern": description}).encode()
-                try:
-                    req = urllib.request.Request(
-                        dest,
-                        data=payload,
-                        method="POST",
-                        headers={"Content-Type": "application/json"},
-                    )
-                    urllib.request.urlopen(req, timeout=5)
-                except Exception as exc:  # pragma: no cover - ignore network errors
-                    print(f"Failed to POST heuristic: {exc}", file=sys.stderr)
-
-

--- a/bankcleanr/rules/manager.py
+++ b/bankcleanr/rules/manager.py
@@ -1,0 +1,58 @@
+"""Manage heuristic classification and persistence."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Dict
+import json
+import os
+import sys
+import urllib.request
+
+from bankcleanr.transaction import Transaction
+from . import regex
+
+
+class Manager:
+    """Handle heuristic classification and learning."""
+
+    def __init__(self) -> None:
+        self.pending: Dict[str, str] = {}
+
+    def classify(self, transactions: Iterable[Transaction]) -> List[str]:
+        """Classify transactions using existing regex patterns."""
+        labels: List[str] = []
+        for tx in transactions:
+            labels.append(regex.classify(tx.description))
+        return labels
+
+    def merge_llm_rules(
+        self, transactions: Iterable[Transaction], labels: Iterable[str]
+    ) -> None:
+        """Record LLM-suggested rules for unknown transactions."""
+        for tx, label in zip(transactions, labels):
+            if label != "unknown" and regex.classify(tx.description) == "unknown":
+                self.pending[label] = tx.description
+
+    def persist(self) -> None:
+        """Persist pending rules and reload patterns."""
+        if not self.pending:
+            return
+        backend_url = os.getenv("BANKCLEANR_BACKEND_URL")
+        token = os.getenv("BANKCLEANR_BACKEND_TOKEN")
+        for label, pattern in self.pending.items():
+            regex.add_pattern(label, pattern)
+            if backend_url and token:
+                dest = f"{backend_url.rstrip('/')}/heuristics?token={token}"
+                payload = json.dumps({"label": label, "pattern": pattern}).encode()
+                try:
+                    req = urllib.request.Request(
+                        dest,
+                        data=payload,
+                        method="POST",
+                        headers={"Content-Type": "application/json"},
+                    )
+                    urllib.request.urlopen(req, timeout=5)
+                except Exception as exc:  # pragma: no cover - ignore network errors
+                    print(f"Failed to POST heuristic: {exc}", file=sys.stderr)
+        regex.reload_patterns()
+        self.pending.clear()

--- a/features/llm.feature
+++ b/features/llm.feature
@@ -32,19 +32,7 @@ Feature: LLM classification
     Given an empty heuristics database
     And a transaction "Coffee shop"
     And the OpenAI adapter is mocked to return "coffee"
-    When I classify transactions with the LLM accepting new patterns
+    When I classify transactions with the LLM
     Then the LLM labels are
       | label |
       | coffee |
-
-  Scenario: Summary of new pattern suggestions is shown once
-    Given an empty heuristics database
-    And duplicate transactions requiring LLM
-    And the OpenAI adapter is mocked to return "coffee"
-    When I classify transactions with the LLM summarising new patterns
-    Then the LLM labels are
-      | label |
-      | coffee |
-      | coffee |
-    And the summary output lists "Coffee shop" 2 times
-    And the user is prompted once for "Coffee shop"

--- a/features/steps/heuristics_steps.py
+++ b/features/steps/heuristics_steps.py
@@ -13,6 +13,7 @@ from sqlmodel import create_engine
 from bankcleanr.transaction import Transaction
 from bankcleanr.rules import regex
 from bankcleanr.rules import heuristics, db_store
+from bankcleanr.rules.manager import Manager
 
 
 @given("sample transactions")
@@ -89,7 +90,9 @@ def backend_env(context):
 @when('I learn a pattern labeled "{label}" for "{description}"')
 def learn_pattern(context, label, description):
     txs = [Transaction(date="2024-01-01", description=description, amount="-1.00")]
-    heuristics.learn_new_patterns(txs, [label], confirm=lambda _: "y")
+    manager = Manager()
+    manager.merge_llm_rules(txs, [label])
+    manager.persist()
 
 
 @then('the backend has a heuristic labeled "{label}"')

--- a/features/steps/recommendation_steps.py
+++ b/features/steps/recommendation_steps.py
@@ -7,7 +7,7 @@ from bankcleanr import recommendation
 @when("I generate recommendations")
 def generate_recommendations(context):
     context.recommendations = recommendation.recommend_transactions(
-        context.txs, provider="openai", confirm=lambda _: "n"
+        context.txs, provider="openai"
     )
     if hasattr(context, "original"):
         PROVIDERS["openai"] = context.original

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -2,10 +2,6 @@ import importlib
 import json
 import urllib.request
 
-import importlib
-import json
-import urllib.request
-
 import pytest
 from sqlmodel import create_engine
 

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -24,11 +24,11 @@ def test_recommend_transactions(monkeypatch, tmp_path):
 
     txs = [Transaction(date="2024-01-01", description="Spotify", amount="-9.99")]
 
-    def dummy_classify(transactions, provider=None, confirm=None):
+    def dummy_classify(transactions, provider=None):
         return ["spotify"]
 
     monkeypatch.setattr("bankcleanr.recommendation.classify_transactions", dummy_classify)
-    recs = recommend_transactions(txs, kb_path=kb_file, confirm=lambda _: "n")
+    recs = recommend_transactions(txs, kb_path=kb_file)
     assert recs[0].category == "spotify"
     assert recs[0].action == "Cancel"
     assert recs[0].info["url"] == "cancel-url"


### PR DESCRIPTION
## Summary
- add rules manager for classifying and persisting heuristics
- remove interactive LLM confirmations and auto-add new patterns
- test that learned rules persist across classifications

## Testing
- `pytest`
- `behave`


------
https://chatgpt.com/codex/tasks/task_e_688de781d0ec832baeeed8aa9927110e