### PR TITLE
Expose LLM rule details and learn new patterns

### DIFF
--- a/bankcleanr/llm/__init__.py
+++ b/bankcleanr/llm/__init__.py
@@ -65,12 +65,13 @@ def classify_transactions(
             "[classify_transactions] masked: %s",
             [tx.description for tx in masked],
         )
-        llm_labels = adapter.classify_transactions(masked)
-        logger.debug("[classify_transactions] llm labels: %s", llm_labels)
+        details = adapter.classify_transactions(masked)
+        logger.debug("[classify_transactions] llm details: %s", details)
+        llm_labels = [d.get("category", "unknown") for d in details]
         for idx, llm_label in zip(unmatched_indexes, llm_labels):
             labels[idx] = llm_label
 
-        manager.merge_llm_rules(unmatched, llm_labels)
+        manager.merge_llm_rules(unmatched, details)
         manager.persist()
 
         refreshed = manager.classify(tx_objs)

--- a/bankcleanr/llm/anthropic.py
+++ b/bankcleanr/llm/anthropic.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Dict, Iterable, List
 from pathlib import Path
 
 from .base import AbstractAdapter
@@ -28,12 +28,16 @@ class AnthropicAdapter(AbstractAdapter):
         self.model = model
         (self.user_heuristics_text, self.global_heuristics_text) = load_heuristics_texts()
 
-    def classify_transactions(self, transactions: Iterable) -> List[str]:
+    def classify_transactions(self, transactions: Iterable) -> List[Dict[str, str | None]]:
         tx_objs = [normalise(tx) for tx in transactions]
         if self.client is None:
-            return ["unknown" for _ in tx_objs]
+            details = [
+                {"category": "unknown", "new_rule": None} for _ in tx_objs
+            ]
+            self.last_details = details
+            return details
 
-        labels: List[str] = []
+        details: List[Dict[str, str | None]] = []
         for tx in tx_objs:
             prompt = CATEGORY_PROMPT.render(
                 txn=tx,
@@ -46,5 +50,6 @@ class AnthropicAdapter(AbstractAdapter):
                 messages=[{"role": "user", "content": prompt}],
             )
             content = resp.content[0].text if hasattr(resp.content[0], "text") else resp.content
-            labels.append(content.strip().lower())
-        return labels
+            details.append({"category": content.strip().lower(), "new_rule": None})
+        self.last_details = details
+        return details

--- a/bankcleanr/llm/base.py
+++ b/bankcleanr/llm/base.py
@@ -1,11 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import List, Mapping
+from typing import Dict, List, Mapping, Optional
 
 
 class AbstractAdapter(ABC):
     """Base interface for LLM adapters."""
 
+    last_details: List[Dict[str, Optional[str]]]
+
     @abstractmethod
-    def classify_transactions(self, transactions: List[Mapping]) -> List[str]:
-        """Return a label for each transaction."""
+    def classify_transactions(
+        self, transactions: List[Mapping]
+    ) -> List[Dict[str, Optional[str]]]:
+        """Return classification details for each transaction.
+
+        Each result is a dictionary containing at least the key ``category`` and
+        optionally ``new_rule`` which, when provided, represents a heuristic
+        regex pattern suggested by the LLM.
+        """
         raise NotImplementedError

--- a/bankcleanr/llm/bfl.py
+++ b/bankcleanr/llm/bfl.py
@@ -4,7 +4,7 @@ This implementation simply proxies to OpenAI for testing purposes."""
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Dict, Iterable, List
 
 from .openai import OpenAIAdapter
 from .base import AbstractAdapter
@@ -14,5 +14,6 @@ class BFLAdapter(AbstractAdapter):
     def __init__(self, *args, **kwargs):
         self.delegate = OpenAIAdapter(*args, **kwargs)
 
-    def classify_transactions(self, transactions: Iterable) -> List[str]:
-        return self.delegate.classify_transactions(transactions)
+    def classify_transactions(self, transactions: Iterable) -> List[Dict[str, str | None]]:
+        self.last_details = self.delegate.classify_transactions(transactions)
+        return self.last_details

--- a/bankcleanr/llm/openai.py
+++ b/bankcleanr/llm/openai.py
@@ -78,21 +78,20 @@ class OpenAIAdapter(AbstractAdapter):
         tasks = [self._aclassify(tx) for tx in txs]
         return await asyncio.gather(*tasks)
 
-    def classify_transactions(self, transactions: Iterable) -> List[str]:
+    def classify_transactions(self, transactions: Iterable) -> List[Dict[str, Any]]:
         tx_objs = [normalise(tx) for tx in transactions]
         if self.llm is None:
-            self.last_details = [
+            details = [
                 {"category": "unknown", "new_rule": None} for _ in tx_objs
             ]
-            return ["unknown" for _ in tx_objs]
+            self.last_details = details
+            return details
         try:
             results = asyncio.run(self._aclassify_batch(tx_objs))
         except Exception as exc:
             logger.error("Failed to classify transactions: %s", exc)
-            self.last_details = [
+            results = [
                 {"category": "unknown", "new_rule": None} for _ in tx_objs
             ]
-            return ["unknown" for _ in tx_objs]
-
         self.last_details = results
-        return [res.get("category", "unknown") for res in results]
+        return results

--- a/bankcleanr/llm/utils.py
+++ b/bankcleanr/llm/utils.py
@@ -27,9 +27,9 @@ def probe_adapter(adapter: AbstractAdapter, timeout: float = 5.0) -> bool:
     with ThreadPoolExecutor(max_workers=1) as ex:
         future = ex.submit(adapter.classify_transactions, [tx])
         try:
-            labels = future.result(timeout=timeout)
+            details = future.result(timeout=timeout)
         except FutureTimeoutError as exc:  # pragma: no cover - defensive
             raise RuntimeError("timed out") from exc
-    if not labels or labels[0] == "unknown":
+    if not details or details[0].get("category") == "unknown":
         raise RuntimeError("no valid response")
     return True

--- a/bankcleanr/rules/manager.py
+++ b/bankcleanr/rules/manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Mapping
 import json
 import os
 import sys
@@ -26,12 +26,14 @@ class Manager:
         return labels
 
     def merge_llm_rules(
-        self, transactions: Iterable[Transaction], labels: Iterable[str]
+        self, transactions: Iterable[Transaction], details: Iterable[Mapping[str, str | None]]
     ) -> None:
         """Record LLM-suggested rules for unknown transactions."""
-        for tx, label in zip(transactions, labels):
-            if label != "unknown" and regex.classify(tx.description) == "unknown":
-                self.pending[label] = tx.description
+        for tx, detail in zip(transactions, details):
+            category = detail.get("category", "unknown")
+            if category != "unknown" and regex.classify(tx.description) == "unknown":
+                pattern = detail.get("new_rule") or tx.description
+                self.pending[category] = pattern
 
     def persist(self) -> None:
         """Persist pending rules and reload patterns."""

--- a/features/steps/heuristics_steps.py
+++ b/features/steps/heuristics_steps.py
@@ -91,7 +91,7 @@ def backend_env(context):
 def learn_pattern(context, label, description):
     txs = [Transaction(date="2024-01-01", description=description, amount="-1.00")]
     manager = Manager()
-    manager.merge_llm_rules(txs, [label])
+    manager.merge_llm_rules(txs, [{"category": label, "new_rule": None}])
     manager.persist()
 
 

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -44,7 +44,7 @@ def _mock_adapter(context, provider, label):
             pass
 
         def classify_transactions(self, transactions):
-            return [label for _ in transactions]
+            return [{"category": label, "new_rule": None} for _ in transactions]
 
     context.original = PROVIDERS[provider]
     context.provider = provider
@@ -91,7 +91,7 @@ def classify_with_capture(context):
 
         def classify_transactions(self, transactions):
             context.captured_descriptions = [tx.description for tx in transactions]
-            return ["ok"]
+            return [{"category": "ok", "new_rule": None}]
 
     context.original = PROVIDERS["openai"]
     PROVIDERS["openai"] = CaptureAdapter
@@ -201,7 +201,7 @@ def classify_live(context, provider):
 
 @then('the returned category is not "unknown"')
 def check_live_category(context):
-    assert context.labels[0] != "unknown"
+    assert context.labels[0]["category"] != "unknown"
 
 
 @then('the summary output lists "{description}" {count:d} times')

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -17,5 +17,5 @@ def test_returns_unknown_when_library_missing(monkeypatch):
 
     adapter = GeminiAdapter(api_key="dummy")
     tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
-    labels = adapter.classify_transactions([tx])
-    assert labels == ["unknown"]
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -14,7 +14,7 @@ class DummyAdapter(AbstractAdapter):
         if self.raise_exc:
             raise RuntimeError("fail")
         time.sleep(self.delay)
-        return ["ok" for _ in transactions]
+        return [{"category": "ok", "new_rule": None} for _ in transactions]
 
 
 def test_probe_adapter_success():

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -54,8 +54,8 @@ def test_classify_returns_unknown_on_failure(monkeypatch):
     monkeypatch.setattr("bankcleanr.llm.openai.ChatOpenAI", lambda *a, **k: FailingChat())
     adapter = OpenAIAdapter(api_key="dummy")
     tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
-    labels = adapter.classify_transactions([tx])
-    assert labels == ["unknown"]
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]
 
 
 def test_classify_transactions_parses_json(monkeypatch):
@@ -63,8 +63,8 @@ def test_classify_transactions_parses_json(monkeypatch):
     monkeypatch.setattr("bankcleanr.llm.openai.ChatOpenAI", lambda *a, **k: DummyChat())
     adapter = OpenAIAdapter(api_key="dummy")
     tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
-    labels = adapter.classify_transactions([tx])
-    assert labels == ["coffee"]
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
     assert adapter.last_details[0] == {
         "category": "coffee",
         "new_rule": ".*COFFEE.*",


### PR DESCRIPTION
## Summary
- standardize adapters to return `{category, new_rule}` details and track them via `last_details`
- merge LLM rule details into the heuristic manager and persist suggested patterns
- add regression test ensuring LLM-suggested rules are stored and reused

## Testing
- `pytest tests/test_heuristics.py tests/test_openai_adapter.py tests/test_llm.py tests/test_llm_utils.py tests/test_gemini_adapter.py -q`
- `behave features/heuristics.feature features/llm.feature`


------
https://chatgpt.com/codex/tasks/task_e_688df97b7e90832b802cb1df3d276d0e