### PR TITLE
feat: capture regex hints from adapters

### DIFF
--- a/bankcleanr/llm/base.py
+++ b/bankcleanr/llm/base.py
@@ -1,16 +1,23 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Mapping, Optional
+from typing import Dict, List, Mapping, Optional, TypedDict
+
+
+class ClassificationDetail(TypedDict, total=False):
+    """Structured result for a classified transaction."""
+
+    category: str
+    new_rule: Optional[str]
 
 
 class AbstractAdapter(ABC):
     """Base interface for LLM adapters."""
 
-    last_details: List[Dict[str, Optional[str]]]
+    last_details: List[ClassificationDetail]
 
     @abstractmethod
     def classify_transactions(
         self, transactions: List[Mapping]
-    ) -> List[Dict[str, Optional[str]]]:
+    ) -> List[ClassificationDetail]:
         """Return classification details for each transaction.
 
         Each result is a dictionary containing at least the key ``category`` and

--- a/bankcleanr/llm/bfl.py
+++ b/bankcleanr/llm/bfl.py
@@ -15,5 +15,8 @@ class BFLAdapter(AbstractAdapter):
         self.delegate = OpenAIAdapter(*args, **kwargs)
 
     def classify_transactions(self, transactions: Iterable) -> List[Dict[str, str | None]]:
-        self.last_details = self.delegate.classify_transactions(transactions)
-        return self.last_details
+        details = self.delegate.classify_transactions(transactions)
+        for d in details:
+            d.setdefault("new_rule", None)
+        self.last_details = details
+        return details

--- a/bankcleanr/llm/mistral.py
+++ b/bankcleanr/llm/mistral.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List
 from pathlib import Path
+import json
+import re
+import logging
 
 from .base import AbstractAdapter
 from .utils import load_heuristics_texts
@@ -11,6 +14,8 @@ from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+logger = logging.getLogger(__name__)
 
 
 class MistralAdapter(AbstractAdapter):
@@ -52,6 +57,22 @@ class MistralAdapter(AbstractAdapter):
                 messages=[{"role": "user", "content": prompt}],
             )
             message = resp.choices[0].message.content if resp.choices else ""
-            details.append({"category": message.strip().lower(), "new_rule": None})
+            content = message.strip()
+            try:
+                if content.startswith("```") and content.endswith("```"):
+                    content = content[3:-3].strip()
+                    content = re.sub(r"^json\s*", "", content, flags=re.IGNORECASE)
+                data = json.loads(content)
+                if not isinstance(data, dict):
+                    raise ValueError
+                details.append(
+                    {
+                        "category": str(data.get("category", "unknown")),
+                        "new_rule": data.get("new_rule"),
+                    }
+                )
+            except Exception as exc:
+                logger.debug("[MistralAdapter] parse error: %s", exc)
+                details.append({"category": content.lower(), "new_rule": None})
         self.last_details = details
         return details

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,28 @@
+import pytest
+from bankcleanr.llm.anthropic import AnthropicAdapter
+from bankcleanr.transaction import Transaction
+
+
+class DummyClient:
+    def __init__(self):
+        class Messages:
+            def create(self, *args, **kwargs):
+                class Msg:
+                    text = '{"category": "coffee", "new_rule": ".*COFFEE.*"}'
+
+                class Resp:
+                    content = [Msg()]
+
+                return Resp()
+
+        self.messages = Messages()
+
+
+def test_classify_parses_json(monkeypatch):
+    adapter = AnthropicAdapter(api_key="dummy")
+    adapter.client = DummyClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
+    assert details[0]["new_rule"] == ".*COFFEE.*"
+

--- a/tests/test_bfl_adapter.py
+++ b/tests/test_bfl_adapter.py
@@ -1,0 +1,22 @@
+from bankcleanr.llm.bfl import BFLAdapter
+from bankcleanr.transaction import Transaction
+
+
+class DummyChat:
+    async def ainvoke(self, messages):
+        class R:
+            content = '{"category": "coffee", "new_rule": ".*COFFEE.*"}'
+
+        return R()
+
+
+def test_classify_parses_json(monkeypatch):
+    monkeypatch.setattr(
+        "bankcleanr.llm.openai.ChatOpenAI", lambda *a, **k: DummyChat()
+    )
+    adapter = BFLAdapter(api_key="dummy")
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
+    assert details[0]["new_rule"] == ".*COFFEE.*"
+

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -19,3 +19,24 @@ def test_returns_unknown_when_library_missing(monkeypatch):
     tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
     details = adapter.classify_transactions([tx])
     assert details == [{"category": "unknown", "new_rule": None}]
+
+
+class DummyModels:
+    def generate_content(self, *args, **kwargs):
+        class Resp:
+            text = '{"category": "coffee", "new_rule": ".*COFFEE.*"}'
+
+        return Resp()
+
+
+class DummyClient:
+    models = DummyModels()
+
+
+def test_classify_parses_json(monkeypatch):
+    adapter = GeminiAdapter(api_key="dummy")
+    adapter.client = DummyClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
+    assert details[0]["new_rule"] == ".*COFFEE.*"

--- a/tests/test_local_ollama_adapter.py
+++ b/tests/test_local_ollama_adapter.py
@@ -1,0 +1,25 @@
+from bankcleanr.llm.local_ollama import LocalOllamaAdapter
+from bankcleanr.transaction import Transaction
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_classify_parses_json(monkeypatch):
+    def fake_post(*args, **kwargs):
+        return DummyResp({"response": '{"category": "coffee", "new_rule": ".*COFFEE.*"}'})
+
+    monkeypatch.setattr("bankcleanr.llm.local_ollama.requests.post", fake_post)
+    adapter = LocalOllamaAdapter()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
+    assert details[0]["new_rule"] == ".*COFFEE.*"

--- a/tests/test_mistral_adapter.py
+++ b/tests/test_mistral_adapter.py
@@ -1,0 +1,23 @@
+from bankcleanr.llm.mistral import MistralAdapter
+from bankcleanr.transaction import Transaction
+
+
+class DummyClient:
+    def chat(self, *args, **kwargs):
+        class Choice:
+            message = type("M", (), {"content": '{"category": "coffee", "new_rule": ".*COFFEE.*"}'})()
+
+        class Resp:
+            choices = [Choice()]
+
+        return Resp()
+
+
+def test_classify_parses_json():
+    adapter = MistralAdapter(api_key="dummy")
+    adapter.client = DummyClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details[0]["category"] == "coffee"
+    assert details[0]["new_rule"] == ".*COFFEE.*"
+


### PR DESCRIPTION
## Summary
- extend LLM adapter base with typed classification detail including optional regex rule
- parse structured responses for new_rule across Anthropic, Gemini, local Ollama, Mistral, and BFL adapters
- add unit tests for adapters covering regex suggestion extraction

## Testing
- `pytest tests/test_openai_adapter.py tests/test_anthropic_adapter.py tests/test_gemini_adapter.py tests/test_local_ollama_adapter.py tests/test_mistral_adapter.py tests/test_bfl_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_688dfe9546cc832bae123329376a519f