### PR TITLE
Add shared retry utility and tests

### DIFF
--- a/bankcleanr/llm/bfl.py
+++ b/bankcleanr/llm/bfl.py
@@ -8,14 +8,22 @@ from typing import Dict, Iterable, List
 
 from .openai import OpenAIAdapter
 from .base import AbstractAdapter
+from .retry import retry
 
 
 class BFLAdapter(AbstractAdapter):
     def __init__(self, *args, **kwargs):
         self.delegate = OpenAIAdapter(*args, **kwargs)
 
+    @retry()
+    def _delegate_classify(self, transactions: Iterable) -> List[Dict[str, str | None]]:
+        return self.delegate.classify_transactions(transactions)
+
     def classify_transactions(self, transactions: Iterable) -> List[Dict[str, str | None]]:
-        details = self.delegate.classify_transactions(transactions)
+        try:
+            details = self._delegate_classify(transactions)
+        except Exception:
+            details = [{"category": "unknown", "new_rule": None} for _ in transactions]
         for d in details:
             d.setdefault("new_rule", None)
         self.last_details = details

--- a/bankcleanr/llm/mistral.py
+++ b/bankcleanr/llm/mistral.py
@@ -10,6 +10,7 @@ import logging
 
 from .base import AbstractAdapter
 from .utils import load_heuristics_texts
+from .retry import retry
 from bankcleanr.transaction import normalise
 from bankcleanr.rules.prompts import CATEGORY_PROMPT
 
@@ -36,6 +37,13 @@ class MistralAdapter(AbstractAdapter):
             self.global_heuristics_text,
         ) = load_heuristics_texts()
 
+    @retry()
+    def _chat(self, prompt: str):
+        return self.client.chat(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
     def classify_transactions(self, transactions: Iterable) -> List[Dict[str, str | None]]:
         tx_objs = [normalise(tx) for tx in transactions]
         if self.client is None:
@@ -52,10 +60,12 @@ class MistralAdapter(AbstractAdapter):
                 user_heuristics=self.user_heuristics_text,
                 global_heuristics=self.global_heuristics_text,
             )
-            resp = self.client.chat(
-                model=self.model,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            try:
+                resp = self._chat(prompt)
+            except Exception as exc:
+                logger.debug("[MistralAdapter] error: %s", exc)
+                details.append({"category": "unknown", "new_rule": None})
+                continue
             message = resp.choices[0].message.content if resp.choices else ""
             content = message.strip()
             try:

--- a/bankcleanr/llm/retry.py
+++ b/bankcleanr/llm/retry.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from tenacity import retry as tenacity_retry, stop_after_attempt, wait_exponential
+
+
+def retry(*, attempts: int = 3, multiplier: float = 1, min_wait: float = 1, max_wait: float = 4):
+    """Return a tenacity retry decorator with exponential backoff."""
+    return tenacity_retry(
+        wait=wait_exponential(multiplier=multiplier, min=min_wait, max=max_wait),
+        stop=stop_after_attempt(attempts),
+    )

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -26,3 +26,22 @@ def test_classify_parses_json(monkeypatch):
     assert details[0]["category"] == "coffee"
     assert details[0]["new_rule"] == ".*COFFEE.*"
 
+
+def test_retries_then_unknown():
+    calls = {"n": 0}
+
+    class FailingMessages:
+        def create(self, *args, **kwargs):
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+    class FailingClient:
+        messages = FailingMessages()
+
+    adapter = AnthropicAdapter(api_key="dummy")
+    adapter.client = FailingClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]
+    assert calls["n"] == 3
+

--- a/tests/test_bfl_adapter.py
+++ b/tests/test_bfl_adapter.py
@@ -20,3 +20,24 @@ def test_classify_parses_json(monkeypatch):
     assert details[0]["category"] == "coffee"
     assert details[0]["new_rule"] == ".*COFFEE.*"
 
+
+def test_retries_then_unknown(monkeypatch):
+    class DummyChat:
+        async def ainvoke(self, messages):
+            return type("R", (), {"content": ""})()
+
+    monkeypatch.setattr("bankcleanr.llm.openai.ChatOpenAI", lambda *a, **k: DummyChat())
+
+    calls = {"n": 0}
+
+    def failing_classify(transactions):
+        calls["n"] += 1
+        raise RuntimeError("boom")
+
+    adapter = BFLAdapter(api_key="dummy")
+    adapter.delegate.classify_transactions = failing_classify
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]
+    assert calls["n"] == 3
+

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -40,3 +40,22 @@ def test_classify_parses_json(monkeypatch):
     details = adapter.classify_transactions([tx])
     assert details[0]["category"] == "coffee"
     assert details[0]["new_rule"] == ".*COFFEE.*"
+
+
+def test_retries_then_unknown():
+    calls = {"n": 0}
+
+    class FailingModels:
+        def generate_content(self, *args, **kwargs):
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+    class FailingClient:
+        models = FailingModels()
+
+    adapter = GeminiAdapter(api_key="dummy")
+    adapter.client = FailingClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]
+    assert calls["n"] == 3

--- a/tests/test_mistral_adapter.py
+++ b/tests/test_mistral_adapter.py
@@ -21,3 +21,19 @@ def test_classify_parses_json():
     assert details[0]["category"] == "coffee"
     assert details[0]["new_rule"] == ".*COFFEE.*"
 
+
+def test_retries_then_unknown():
+    calls = {"n": 0}
+
+    class FailingClient:
+        def chat(self, *args, **kwargs):
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+    adapter = MistralAdapter(api_key="dummy")
+    adapter.client = FailingClient()
+    tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")
+    details = adapter.classify_transactions([tx])
+    assert details == [{"category": "unknown", "new_rule": None}]
+    assert calls["n"] == 3
+


### PR DESCRIPTION
## Summary
- add reusable tenacity-based retry helper
- retry network calls in Anthropic, Gemini, Mistral, LocalOllama and BFL adapters
- test retry behaviour for transient failures

## Testing
- `pytest tests/test_anthropic_adapter.py tests/test_gemini_adapter.py tests/test_mistral_adapter.py tests/test_local_ollama_adapter.py tests/test_bfl_adapter.py`
- `behave`


------
https://chatgpt.com/codex/tasks/task_e_688e0412fea8832b866d3aaa2cbca481