### PR TITLE
feat: add LLM cost manager

### DIFF
--- a/bankcleanr/llm/cost_manager.py
+++ b/bankcleanr/llm/cost_manager.py
@@ -1,0 +1,70 @@
+import json
+import os
+from pathlib import Path
+from datetime import date
+from typing import Callable
+
+class DailyCostManager:
+    """Track and persist daily LLM spend."""
+
+    def __init__(
+        self,
+        max_cost: float | None = None,
+        path: Path | None = None,
+        today_fn: Callable[[], date] | None = None,
+    ) -> None:
+        self.max_cost = (
+            max_cost
+            if max_cost is not None
+            else float(os.getenv("MAX_LLM_COST_PER_DAY", "inf"))
+        )
+        default_path = Path(os.getenv("LLM_COST_PATH", Path.home() / ".bankcleanr_llm_cost.json"))
+        self.path = path or default_path
+        self.today_fn = today_fn or date.today
+        self._data = {"date": self.today_fn().isoformat(), "spend": 0.0}
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            try:
+                data = json.loads(self.path.read_text())
+            except Exception:
+                data = {}
+            today = self.today_fn().isoformat()
+            if data.get("date") == today:
+                self._data = {"date": today, "spend": float(data.get("spend", 0.0))}
+            else:
+                self._data = {"date": today, "spend": 0.0}
+        else:
+            self._save()
+
+    def _save(self) -> None:
+        self.path.write_text(json.dumps(self._data))
+
+    def _ensure_today(self) -> None:
+        today = self.today_fn().isoformat()
+        if self._data.get("date") != today:
+            self._data = {"date": today, "spend": 0.0}
+            self._save()
+
+    @property
+    def spend(self) -> float:
+        self._ensure_today()
+        return float(self._data.get("spend", 0.0))
+
+    def check_and_add(self, cost: float) -> None:
+        """Raise if adding cost would exceed max; otherwise persist."""
+        self._ensure_today()
+        new_spend = self._data["spend"] + cost
+        if new_spend > self.max_cost:
+            raise RuntimeError("daily llm cost limit exceeded")
+        self._data["spend"] = new_spend
+        self._save()
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimation using 4 chars per token."""
+    return max(1, len(text) // 4)
+
+
+cost_manager = DailyCostManager()

--- a/tests/test_cost_manager.py
+++ b/tests/test_cost_manager.py
@@ -1,0 +1,46 @@
+from datetime import date, timedelta
+
+import pytest
+from bankcleanr.llm.cost_manager import DailyCostManager
+
+
+def test_blocks_when_limit_exceeded(tmp_path):
+    path = tmp_path / "cost.json"
+    manager = DailyCostManager(max_cost=1.0, path=path, today_fn=lambda: date(2024, 1, 1))
+    manager.check_and_add(0.6)
+    with pytest.raises(RuntimeError):
+        manager.check_and_add(0.5)
+
+
+def test_resets_each_day(tmp_path):
+    today = date(2024, 1, 1)
+    path = tmp_path / "cost.json"
+    manager = DailyCostManager(max_cost=2.0, path=path, today_fn=lambda: today)
+    manager.check_and_add(1.5)
+    # simulate next day
+    manager.today_fn = lambda: today + timedelta(days=1)
+    manager.check_and_add(1.5)  # should not raise
+    assert manager.spend == 1.5
+
+
+def test_adapter_blocks_on_limit(monkeypatch, tmp_path):
+    from bankcleanr.llm.openai import OpenAIAdapter
+
+    class DummyChat:
+        def __init__(self):
+            self.called = False
+
+        async def ainvoke(self, msgs):
+            self.called = True
+            class R:
+                content = "{\"category\": \"coffee\"}"
+            return R()
+
+    chat = DummyChat()
+    monkeypatch.setattr("bankcleanr.llm.openai.ChatOpenAI", lambda *a, **k: chat)
+    manager = DailyCostManager(max_cost=0.0, path=tmp_path / "cost.json", today_fn=lambda: date(2024, 1, 1))
+    monkeypatch.setattr("bankcleanr.llm.openai.cost_manager", manager)
+    adapter = OpenAIAdapter(api_key="key")
+    details = adapter.classify_transactions([{"description": "coffee"}])
+    assert chat.called is False
+    assert details[0]["category"] == "unknown"


### PR DESCRIPTION
## Summary
- add reusable daily cost tracker for LLM usage with env-configurable limit
- integrate token cost estimation and cost checks across LLM adapters
- cover cost manager behaviour with unit tests

## Testing
- `pytest`
- `pytest tests/test_backend_app.py`
- `behave`


------
https://chatgpt.com/codex/tasks/task_e_688e08c67fe0832bbe78964e0a912fc1