### PR TITLE
Refactor heuristics to use Manager

### DIFF
--- a/bankcleanr/rules/heuristics.py
+++ b/bankcleanr/rules/heuristics.py
@@ -1,15 +1,28 @@
-"""Local heuristics for quick transaction classification."""
+"""Local heuristics for quick transaction classification.
+
+This module now delegates to :class:`~bankcleanr.rules.manager.Manager`
+so that all classification uses the same code path as the LLM backed
+classifier.  Previously the logic here duplicated the regex lookups which
+meant any refactor in :mod:`manager` had to be mirrored.  By funnelling
+everything through ``Manager`` we ensure the heuristics used by the
+auto-learning LLM service are identical to those used for the
+"heuristics only" mode.
+"""
 
 from typing import Iterable, List
 
 from bankcleanr.transaction import normalise
-from . import regex
+from .manager import Manager
 
 
 def classify_transactions(transactions: Iterable) -> List[str]:
-    """Classify transactions locally using regex patterns."""
-    labels: List[str] = []
-    for tx in transactions:
-        tx_obj = normalise(tx)
-        labels.append(regex.classify(tx_obj.description))
-    return labels
+    """Classify transactions locally using regex patterns.
+
+    The input transactions can be dictionaries, dataclass instances or
+    :class:`~bankcleanr.transaction.Transaction` objects.  They are first
+    normalised and then passed to :class:`Manager` for classification.
+    """
+
+    manager = Manager()
+    tx_objs = [normalise(tx) for tx in transactions]
+    return manager.classify(tx_objs)


### PR DESCRIPTION
## Summary
- delegate heuristics classification to Manager to share code path with LLM-backed classification

## Testing
- `poetry run pytest`
- `poetry run behave features/analytics.feature features/api.feature features/heuristics.feature features/llm.feature features/recommendation.feature` *(fails: features/llm.feature:20 Account details are masked before sending to the LLM)*


------
https://chatgpt.com/codex/tasks/task_e_688e1175be1c832b8c664197591f0def