### PR TITLE
refactor: clean up typing imports

### DIFF
--- a/bankcleanr/llm/base.py
+++ b/bankcleanr/llm/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Mapping, Optional, TypedDict
+from typing import List, Mapping, Optional, TypedDict
 
 
 class ClassificationDetail(TypedDict, total=False):

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,4 +1,3 @@
-import pytest
 from bankcleanr.llm.anthropic import AnthropicAdapter
 from bankcleanr.transaction import Transaction
 


### PR DESCRIPTION
## Summary
- remove unused Dict import from LLM base adapter
- fix unused pytest import in Anthropic adapter tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688e170f4b08832b8af2f1e66739c585