### PR TITLE
Reset heuristics database before LLM masking test

### DIFF
--- a/features/llm.feature
+++ b/features/llm.feature
@@ -18,7 +18,8 @@ Feature: LLM classification
       | coffee  |
 
   Scenario: Account details are masked before sending to the LLM
-    Given a transaction containing account details
+    Given an empty heuristics database
+    And a transaction containing account details
     When I classify the transaction with a capture adapter
     Then the adapter received the masked transaction
 

--- a/features/steps/llm_steps.py
+++ b/features/steps/llm_steps.py
@@ -78,6 +78,7 @@ def check_labels(context):
 
 @given("a transaction containing account details")
 def transaction_with_account(context):
+    empty_heuristics_db(context)
     context.txs = [
         Transaction(date="2024-01-01", description="Send 12-34-56 12345678", amount="-1.00")
     ]


### PR DESCRIPTION
## Summary
- ensure heuristics DB is cleared before masking test scenario
- reuse DB reset logic in `transaction_with_account` step for scenario isolation

## Testing
- `poetry run coverage run -m pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_688e2246f92c832ba461d53054d3f5bb