### PR TITLE
Document macOS testing and cost limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ lint:
 
 e2e:
 	@if command -v podman >/dev/null 2>&1; then \
-	podman compose up --build frontend e2e; \
+	    podman compose up --build frontend e2e; \
+	elif docker compose version >/dev/null 2>&1; then \
+	    docker compose up --build frontend e2e; \
 	else \
-	docker compose up --build frontend e2e; \
+	    docker-compose up --build frontend e2e; \
 	fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You can run the tests directly or via the `Makefile`:
 
 ```bash
 make test
+# run Cypress end-to-end tests (requires Docker Desktop or Podman)
+make e2e
 # or run them manually
 poetry run pytest
 poetry run behave
@@ -144,9 +146,13 @@ provider:
 - `MISTRAL_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `BFL_API_KEY` (falls back to `OPENAI_API_KEY` if unset)
+- `MAX_LLM_COST_PER_DAY` (optional, limit spend in GBP)
+- `LLM_COST_PATH` (optional, where to track daily spend)
 
 Export the appropriate variable before running the CLI so the adapter can talk
 to the LLM service.
+The behaviour and end-to-end suites will skip scenarios that require a live
+LLM if the corresponding key is missing.
 
 When running the behaviour tests, the live classification steps verify that the
 API key isn't a placeholder and perform a short connectivity check. If this


### PR DESCRIPTION
## Summary
- document how to run Cypress end-to-end tests via `make e2e` and describe new cost guard environment variables
- extend Makefile e2e target to work with Podman, `docker compose`, or `docker-compose`

## Testing
- `make test`
- `make e2e` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_688e2730bb50832bb110c3284c5267e9