### PR TITLE
test: remove unused fixture parameter

### DIFF
--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -17,7 +17,7 @@ class DummyClient:
         self.messages = Messages()
 
 
-def test_classify_parses_json(monkeypatch):
+def test_classify_parses_json():
     adapter = AnthropicAdapter(api_key="dummy")
     adapter.client = DummyClient()
     tx = Transaction(date="2024-01-01", description="Coffee", amount="-1")


### PR DESCRIPTION
## Summary
- remove unnecessary monkeypatch fixture from Anthropic adapter test

## Testing
- `poetry run pytest tests/test_anthropic_adapter.py::test_classify_parses_json`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2db51288832b8984b9e838ee55ca