### PR TITLE
Implement HMAC auth with bypass and tests

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,45 @@
+import base64
+import hashlib
+import hmac
+import os
+import time
+from fastapi import Header, HTTPException
+
+SECRET_KEY = os.environ.get("AUTH_SECRET_KEY", "changeme")
+BYPASS_ENV = "AUTH_BYPASS"
+
+
+def generate_token(data: str, expires_in: int = 3600) -> str:
+    expiry = int(time.time()) + expires_in
+    msg = f"{data}:{expiry}".encode()
+    sig = hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).digest()
+    token = base64.urlsafe_b64encode(msg + b":" + sig).decode()
+    return token
+
+
+def validate_token(token: str, data: str) -> bool:
+    try:
+        decoded = base64.urlsafe_b64decode(token.encode())
+        parts = decoded.split(b":")
+        if len(parts) != 3:
+            return False
+        msg = b":".join(parts[:-1])
+        sig = parts[-1]
+        expected = hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).digest()
+        if not hmac.compare_digest(sig, expected):
+            return False
+        payload, expiry = parts[0].decode(), int(parts[1])
+        if payload != data:
+            return False
+        if time.time() > expiry:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def auth_dependency(token: str = Header(None, alias="X-Auth-Token")) -> None:
+    if os.getenv(BYPASS_ENV):
+        return
+    if not token or not validate_token(token, "auth"):
+        raise HTTPException(status_code=401, detail="Unauthorized")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+import pytest
+from fastapi import HTTPException
+
+from backend.auth import generate_token, validate_token, auth_dependency
+
+
+def test_token_expiry():
+    token = generate_token("auth", expires_in=-1)
+    assert not validate_token(token, "auth")
+
+
+def test_token_tamper_detection():
+    token = generate_token("auth")
+    tampered = token[:-1] + ("A" if token[-1] != "A" else "B")
+    assert not validate_token(tampered, "auth")
+
+
+def test_auth_bypass(monkeypatch):
+    monkeypatch.delenv("AUTH_BYPASS", raising=False)
+    with pytest.raises(HTTPException):
+        auth_dependency(token=None)
+    monkeypatch.setenv("AUTH_BYPASS", "1")
+    auth_dependency(token=None)  # should not raise

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
@@ -11,6 +12,7 @@ from backend.database import get_session
 
 @pytest.fixture(name="client")
 def client_fixture():
+    os.environ["AUTH_BYPASS"] = "1"
     engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
     SQLModel.metadata.create_all(engine)
 
@@ -22,6 +24,7 @@ def client_fixture():
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+    os.environ.pop("AUTH_BYPASS", None)
 
 
 def test_upload_and_status(client: TestClient):


### PR DESCRIPTION
## Summary
- add HMAC-based token utility with environment bypass option
- secure backend routes with auth dependency and signed download links
- cover token expiry, tampering, and bypass in tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f22067648832b8bb2b67b0b66fd94