### PR TITLE
Add upload content-type and size validation

### DIFF
--- a/features/backend_api.feature
+++ b/features/backend_api.feature
@@ -18,3 +18,13 @@ Feature: Backend API
     Given the API client
     When I generate an expired signed download URL
     Then accessing the URL returns 403
+
+  Scenario: Rejecting uploads with unsupported content type
+    Given the API client
+    When I upload with content type "application/json"
+    Then the response status is 415
+
+  Scenario: Rejecting uploads over 100 MB
+    Given the API client
+    When I upload data of size 101 MB
+    Then the response status is 413


### PR DESCRIPTION
## Summary
- enforce allowed MIME types and 100MB size limit in `/upload`
- support gzip-encoded bodies and reject oversized requests
- add unit and BDD tests for invalid type and large payloads

## Testing
- `make unit`
- `make behave`


------
https://chatgpt.com/codex/tasks/task_e_688f379a3050832b9bd592821f13213b