### PR TITLE
Implement rule engine and integrate into classification

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -17,7 +17,13 @@ class ProcessingJob(SQLModel, table=True):
 
 class UserRule(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
-    rule_text: str
+    user_id: Optional[int] = None
+    label: str
+    pattern: str
+    priority: int = 0
+    confidence: float = 1.0
+    version: int = 1
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class ClassificationResult(SQLModel, table=True):
@@ -29,3 +35,4 @@ class ClassificationResult(SQLModel, table=True):
 
 class ClassifyRequest(SQLModel):
     job_id: int
+    user_id: int = 0

--- a/features/rule_engine.feature
+++ b/features/rule_engine.feature
@@ -1,0 +1,7 @@
+Feature: Rule engine
+  Scenario: User rule overrides global rule
+    Given the API client
+    When I create a user rule with label "coffee" pattern "coffee" priority 5 for user 1
+    And I upload text "coffee shop"
+    And I classify with user id 1
+    Then the classification label is "coffee"

--- a/features/steps/backend_api_steps.py
+++ b/features/steps/backend_api_steps.py
@@ -46,13 +46,13 @@ def then_job_status(context, status):
 
 @when('I create a rule "{text}"')
 def when_create_rule(context, text):
-    context.client.post("/rules", json={"rule_text": text})
+    context.client.post("/rules", json={"label": text, "pattern": text})
 
 
 @then('the rules list contains "{text}"')
 def then_rules_list(context, text):
     resp = context.client.get("/rules")
-    rules = [r["rule_text"] for r in resp.json()]
+    rules = [r["label"] for r in resp.json()]
     assert text in rules
     context.client.close()
     app.dependency_overrides.clear()

--- a/features/steps/rule_engine_steps.py
+++ b/features/steps/rule_engine_steps.py
@@ -1,0 +1,31 @@
+import os
+from behave import when, then
+
+from features.steps.backend_api_steps import _setup_client, app
+
+
+@when('I create a user rule with label "{label}" pattern "{pattern}" priority {priority:d} for user {user_id:d}')
+def when_create_user_rule(context, label, pattern, priority, user_id):
+    if not hasattr(context, "client"):
+        _setup_client(context)
+    context.client.post(
+        "/rules",
+        json={"user_id": user_id, "label": label, "pattern": pattern, "priority": priority},
+    )
+    context.user_id = user_id
+
+
+@when('I classify with user id {user_id:d}')
+def when_classify(context, user_id):
+    resp = context.client.post(
+        "/classify", json={"job_id": context.job_id, "user_id": user_id}
+    )
+    context.classification = resp.json()
+
+
+@then('the classification label is "{label}"')
+def then_classification_label(context, label):
+    assert context.classification["label"] == label
+    context.client.close()
+    app.dependency_overrides.clear()
+    os.environ.pop("AUTH_BYPASS", None)

--- a/rules/__init__.py
+++ b/rules/__init__.py
@@ -1,0 +1,1 @@
+# Rules package

--- a/rules/engine.py
+++ b/rules/engine.py
@@ -1,0 +1,55 @@
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Rule(BaseModel):
+    label: str
+    pattern: str
+    priority: int = 0
+    confidence: float = 1.0
+    version: int = 1
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    user_id: Optional[int] = None
+
+
+def load_global_rules(path: Optional[str] = None) -> List[Rule]:
+    """Load global rules from heuristic_rule_v1.json."""
+    if path is None:
+        path = Path(__file__).with_name("heuristic_rule_v1.json")
+    else:
+        path = Path(path)
+    with path.open() as f:
+        data = json.load(f)
+    return [Rule(**item) for item in data]
+
+
+def _precedence_key(rule: Rule):
+    # higher values should come first
+    return (rule.priority, rule.confidence, rule.version, rule.updated_at)
+
+
+def merge_rules(global_rules: Iterable[Rule], user_rules: Iterable[Rule]) -> List[Rule]:
+    """Merge global and user rules applying precedence and overrides."""
+    combined: dict[tuple[str, str], Rule] = {}
+    for rule in global_rules:
+        key = (rule.label, rule.pattern)
+        existing = combined.get(key)
+        if not existing or _precedence_key(rule) > _precedence_key(existing):
+            combined[key] = rule
+    for rule in user_rules:
+        key = (rule.label, rule.pattern)
+        # user rule always overrides
+        combined[key] = rule
+    return sorted(combined.values(), key=_precedence_key, reverse=True)
+
+
+def evaluate(text: str, rules: Iterable[Rule]) -> Optional[str]:
+    for rule in sorted(rules, key=_precedence_key, reverse=True):
+        if re.search(rule.pattern, text, flags=re.IGNORECASE):
+            return rule.label
+    return None

--- a/rules/heuristic_rule_v1.json
+++ b/rules/heuristic_rule_v1.json
@@ -1,0 +1,18 @@
+[
+  {
+    "label": "coffee",
+    "pattern": "coffee",
+    "priority": 1,
+    "confidence": 0.9,
+    "version": 1,
+    "updated_at": "2024-01-01T00:00:00Z"
+  },
+  {
+    "label": "tea",
+    "pattern": "tea",
+    "priority": 1,
+    "confidence": 0.8,
+    "version": 1,
+    "updated_at": "2024-01-01T00:00:00Z"
+  }
+]

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta
+
+from rules.engine import Rule, merge_rules, evaluate
+
+
+def test_user_rule_overrides_global():
+    g = [Rule(label="coffee", pattern="coffee", priority=1)]
+    u = [Rule(label="coffee", pattern="coffee", priority=0, user_id=1)]
+    merged = merge_rules(g, u)
+    assert merged[0].user_id == 1
+
+
+def test_precedence_priority_confidence_version_updated():
+    now = datetime.utcnow()
+    earlier = now - timedelta(days=1)
+    rules = [
+        Rule(label="a", pattern="a", priority=1, confidence=0.9, version=1, updated_at=earlier),
+        Rule(label="a", pattern="a", priority=2, confidence=0.8, version=1, updated_at=now),
+    ]
+    merged = merge_rules(rules, [])
+    assert merged[0].priority == 2
+
+    rules = [
+        Rule(label="b", pattern="b", priority=1, confidence=0.8, version=1, updated_at=now),
+        Rule(label="b", pattern="b", priority=1, confidence=0.9, version=1, updated_at=earlier),
+    ]
+    merged = merge_rules(rules, [])
+    assert merged[0].confidence == 0.9
+
+    rules = [
+        Rule(label="c", pattern="c", priority=1, confidence=0.9, version=2, updated_at=earlier),
+        Rule(label="c", pattern="c", priority=1, confidence=0.9, version=1, updated_at=now),
+    ]
+    merged = merge_rules(rules, [])
+    assert merged[0].version == 2
+
+    rules = [
+        Rule(label="d", pattern="d", priority=1, confidence=0.9, version=1, updated_at=now),
+        Rule(label="d", pattern="d", priority=1, confidence=0.9, version=1, updated_at=earlier),
+    ]
+    merged = merge_rules(rules, [])
+    assert merged[0].updated_at == now
+
+
+def test_evaluate_uses_precedence():
+    rules = [
+        Rule(label="low", pattern="shop", priority=1),
+        Rule(label="high", pattern="shop", priority=5),
+    ]
+    label = evaluate("coffee shop", merge_rules(rules, []))
+    assert label == "high"


### PR DESCRIPTION
## Summary
- add rules engine with priority/confidence/version precedence and JSON loader
- extend backend models and classification to apply merged global and per-user rules
- cover rule engine with unit, BDD, and API tests

## Testing
- `pytest`
- `behave features/rule_engine.feature`
- `make e2e` *(fails: docker-compose: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f96bf6e6c832ba37318afaafd0692