### PR TITLE
Add schema definitions for heuristics and summary

### DIFF
--- a/schemas/heuristic_rule_v1.json
+++ b/schemas/heuristic_rule_v1.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bankcleanr/schemas/heuristic_rule_v1.json",
+  "title": "Heuristic Rule v1",
+  "type": "object",
+  "required": [
+    "id",
+    "scope",
+    "active",
+    "match",
+    "action",
+    "provenance",
+    "priority",
+    "version",
+    "confidence"
+  ],
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "scope": { "type": "string", "enum": ["global", "user"] },
+    "owner_user_id": { "type": "string", "nullable": true },
+    "active": { "type": "boolean", "default": true },
+    "priority": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Lower number = higher precedence"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "provenance": { "type": "string", "enum": ["system", "llm", "user"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "title": { "type": "string" },
+    "notes": { "type": "string" },
+
+    "match": {
+      "type": "object",
+      "required": ["type", "pattern", "fields"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["exact", "contains", "regex", "signature"]
+        },
+        "pattern": { "type": "string" },
+        "flags": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["i", "m"] }
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "description",
+              "counterparty",
+              "reference",
+              "mcc",
+              "merchant_signature"
+            ]
+          },
+          "minItems": 1
+        }
+      }
+    },
+
+    "action": {
+      "type": "object",
+      "required": ["category"],
+      "properties": {
+        "merchant_canonical": { "type": "string" },
+        "label": { "type": "string" },
+        "category": { "type": "string" },
+        "subcategory": { "type": "string" }
+      }
+    },
+
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": { "type": "string" },
+          "amount": { "type": "number" },
+          "date": { "type": "string", "format": "date" }
+        }
+      }
+    }
+  }
+}
+

--- a/schemas/summary_v1.json
+++ b/schemas/summary_v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bankcleanr/schemas/summary_v1.json",
+  "title": "Analysis Summary v1",
+  "type": "object",
+  "required": ["job_id", "user_id", "period", "currency", "totals", "categories"],
+  "properties": {
+    "job_id": { "type": "string", "format": "uuid" },
+    "user_id": { "type": "string" },
+    "period": {
+      "type": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string", "format": "date" },
+        "end": { "type": "string", "format": "date" }
+      }
+    },
+    "currency": { "type": "string", "default": "GBP" },
+    "generated_at": { "type": "string", "format": "date-time" },
+
+    "totals": {
+      "type": "object",
+      "required": ["income", "expenses", "net"],
+      "properties": {
+        "income": { "type": "number" },
+        "expenses": { "type": "number" },
+        "net": { "type": "number" }
+      }
+    },
+
+    "categories": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "total", "count"],
+        "properties": {
+          "name": { "type": "string" },
+          "total": { "type": "number" },
+          "count": { "type": "integer" },
+          "sample_merchants": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+
+    "recurring": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["merchant", "cadence", "avg_amount", "count"],
+        "properties": {
+          "merchant": { "type": "string" },
+          "cadence": { "type": "string", "enum": ["weekly", "monthly", "quarterly", "yearly"] },
+          "avg_amount": { "type": "number" },
+          "amount_stddev": { "type": "number" },
+          "count": { "type": "integer" },
+          "first_seen": { "type": "string", "format": "date" },
+          "last_seen": { "type": "string", "format": "date" }
+        }
+      }
+    },
+
+    "highlights": {
+      "type": "object",
+      "properties": {
+        "overspending": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "anomalies": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+
+
+def load_schema(name: str) -> dict:
+    with open(SCHEMAS_DIR / name) as f:
+        return json.load(f)
+
+
+def test_heuristic_rule_valid_example():
+    schema = load_schema("heuristic_rule_v1.json")
+    example = {
+        "id": "123e4567-e89b-12d3-a456-426614174000",
+        "scope": "user",
+        "owner_user_id": "user1",
+        "active": True,
+        "priority": 1,
+        "version": 1,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+        "provenance": "system",
+        "confidence": 0.9,
+        "title": "Coffee shops",
+        "notes": "Matches coffee merchants",
+        "match": {
+            "type": "contains",
+            "pattern": "coffee",
+            "flags": ["i"],
+            "fields": ["description"],
+        },
+        "action": {"category": "Food", "label": "Coffee"},
+        "examples": [
+            {
+                "description": "Starbucks",
+                "amount": 3.5,
+                "date": "2024-01-02",
+            }
+        ],
+    }
+
+    validate(example, schema)
+
+
+def test_heuristic_rule_missing_required_field():
+    schema = load_schema("heuristic_rule_v1.json")
+    example = {
+        # Missing 'id'
+        "scope": "global",
+        "active": True,
+        "match": {"type": "exact", "pattern": "coffee", "fields": ["description"]},
+        "action": {"category": "Food"},
+        "provenance": "system",
+        "priority": 1,
+        "version": 1,
+        "confidence": 0.9,
+    }
+
+    with pytest.raises(ValidationError):
+        validate(example, schema)
+
+
+def test_summary_valid_example():
+    schema = load_schema("summary_v1.json")
+    example = {
+        "job_id": "123e4567-e89b-12d3-a456-426614174000",
+        "user_id": "user123",
+        "period": {"start": "2024-01-01", "end": "2024-01-31"},
+        "currency": "GBP",
+        "generated_at": "2024-02-01T00:00:00Z",
+        "totals": {"income": 1000.0, "expenses": 500.0, "net": 500.0},
+        "categories": [
+            {
+                "name": "Groceries",
+                "total": 200.0,
+                "count": 5,
+                "sample_merchants": ["Tesco"],
+            }
+        ],
+        "recurring": [
+            {
+                "merchant": "Netflix",
+                "cadence": "monthly",
+                "avg_amount": 10.0,
+                "amount_stddev": 0.0,
+                "count": 12,
+                "first_seen": "2023-03-01",
+                "last_seen": "2024-02-01",
+            }
+        ],
+        "highlights": {"overspending": ["Groceries"], "anomalies": []},
+    }
+
+    validate(example, schema)
+
+
+def test_summary_missing_required_field():
+    schema = load_schema("summary_v1.json")
+    example = {
+        # Missing 'categories'
+        "job_id": "123e4567-e89b-12d3-a456-426614174000",
+        "user_id": "user123",
+        "period": {"start": "2024-01-01", "end": "2024-01-31"},
+        "currency": "GBP",
+        "totals": {"income": 1000.0, "expenses": 500.0, "net": 500.0},
+    }
+
+    with pytest.raises(ValidationError):
+        validate(example, schema)
+


### PR DESCRIPTION
## Summary
- add JSON Schema for heuristic rules and analysis summaries
- validate schemas and add unit tests for example data

## Testing
- `python -m jsonschema -i schemas/heuristic_rule_v1.json /tmp/meta.json`
- `python -m jsonschema -i schemas/summary_v1.json /tmp/meta.json`
- `PYTHONPATH=. pytest tests/test_schemas.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `behave` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_688f9c18ca58832bb080f3fead04174d