### PR TITLE
Organize imports for extraction steps

### DIFF
--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -1,10 +1,9 @@
 import os
 import subprocess
 import tempfile
+from behave import given, when, then
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
-from behave import given, when, then
-
 
 def _create_pdf(path: str) -> None:
     lines = [


### PR DESCRIPTION
## Summary
- reorder imports in extract steps and ensure os and subprocess are available

## Testing
- `poetry run pytest`
- `poetry run behave`

------
https://chatgpt.com/codex/tasks/task_e_688fc54719b4832b877fcfad18beb109