### PR TITLE
Refactor rules engine for new heuristic schema

### DIFF
--- a/rules/heuristic_rule_v1.json
+++ b/rules/heuristic_rule_v1.json
@@ -1,18 +1,42 @@
 [
   {
-    "label": "coffee",
-    "pattern": "coffee",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "scope": "global",
+    "active": true,
     "priority": 1,
-    "confidence": 0.9,
     "version": 1,
-    "updated_at": "2024-01-01T00:00:00Z"
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z",
+    "provenance": "system",
+    "confidence": 0.9,
+    "match": {
+      "type": "contains",
+      "pattern": "coffee",
+      "fields": ["description"]
+    },
+    "action": {
+      "label": "coffee",
+      "category": "drink"
+    }
   },
   {
-    "label": "tea",
-    "pattern": "tea",
-    "priority": 1,
-    "confidence": 0.8,
+    "id": "22222222-2222-2222-2222-222222222222",
+    "scope": "global",
+    "active": true,
+    "priority": 2,
     "version": 1,
-    "updated_at": "2024-01-01T00:00:00Z"
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z",
+    "provenance": "system",
+    "confidence": 0.8,
+    "match": {
+      "type": "contains",
+      "pattern": "tea",
+      "fields": ["description"]
+    },
+    "action": {
+      "label": "tea",
+      "category": "drink"
+    }
   }
 ]

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -3,49 +3,97 @@ from datetime import datetime, timedelta
 from rules.engine import Rule, merge_rules, evaluate
 
 
+def _base_rule(**kwargs):
+    base = {
+        "scope": "global",
+        "priority": 1,
+        "version": 1,
+        "provenance": "system",
+        "confidence": 1.0,
+        "match": {"type": "contains", "pattern": "x", "fields": ["description"]},
+        "action": {"label": "x", "category": "misc"},
+    }
+    base.update(kwargs)
+    return Rule(**base)
+
+
 def test_user_rule_overrides_global():
-    g = [Rule(label="coffee", pattern="coffee", priority=1)]
-    u = [Rule(label="coffee", pattern="coffee", priority=0, user_id=1)]
+    g = [_base_rule(match={"type": "contains", "pattern": "coffee", "fields": ["description"]}, action={"label": "coffee", "category": "drink"})]
+    u = [Rule(scope="user", owner_user_id="1", priority=0, version=1, provenance="user", confidence=1.0,
+             match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
+             action={"label": "coffee", "category": "drink"})]
     merged = merge_rules(g, u)
-    assert merged[0].user_id == 1
+    assert merged[0].scope == "user"
 
 
 def test_precedence_priority_confidence_version_updated():
     now = datetime.utcnow()
     earlier = now - timedelta(days=1)
     rules = [
-        Rule(label="a", pattern="a", priority=1, confidence=0.9, version=1, updated_at=earlier),
-        Rule(label="a", pattern="a", priority=2, confidence=0.8, version=1, updated_at=now),
+        _base_rule(priority=2, confidence=0.8, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "misc"}),
+        _base_rule(priority=1, confidence=0.9, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "misc"})
     ]
     merged = merge_rules(rules, [])
-    assert merged[0].priority == 2
+    assert merged[0].priority == 1
 
     rules = [
-        Rule(label="b", pattern="b", priority=1, confidence=0.8, version=1, updated_at=now),
-        Rule(label="b", pattern="b", priority=1, confidence=0.9, version=1, updated_at=earlier),
+        _base_rule(confidence=0.8, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "misc"}),
+        _base_rule(confidence=0.9, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "misc"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].confidence == 0.9
 
     rules = [
-        Rule(label="c", pattern="c", priority=1, confidence=0.9, version=2, updated_at=earlier),
-        Rule(label="c", pattern="c", priority=1, confidence=0.9, version=1, updated_at=now),
+        _base_rule(version=1, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "misc"}),
+        _base_rule(version=2, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "misc"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].version == 2
 
     rules = [
-        Rule(label="d", pattern="d", priority=1, confidence=0.9, version=1, updated_at=now),
-        Rule(label="d", pattern="d", priority=1, confidence=0.9, version=1, updated_at=earlier),
+        _base_rule(updated_at=earlier, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "misc"}),
+        _base_rule(updated_at=now, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "misc"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].updated_at == now
 
 
+def test_match_strategies():
+    exact_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+                      match={"type": "exact", "pattern": "Coffee Shop", "fields": ["description"]},
+                      action={"label": "exact", "category": "drink"})
+    contains_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+                         match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
+                         action={"label": "contains", "category": "drink"})
+    regex_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+                      match={"type": "regex", "pattern": "^coffee", "flags": ["i"], "fields": ["description"]},
+                      action={"label": "regex", "category": "drink"})
+    signature_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+                          match={"type": "signature", "pattern": "CoffeeShop", "fields": ["description"]},
+                          action={"label": "signature", "category": "drink"})
+
+    assert evaluate({"description": "Coffee Shop"}, [exact_rule]) == "exact"
+    assert evaluate({"description": "my coffee"}, [contains_rule]) == "contains"
+    assert evaluate({"description": "Coffee beans"}, [regex_rule]) == "regex"
+    assert evaluate({"description": "coffee-shop"}, [signature_rule]) == "signature"
+
+
+def test_field_selection():
+    rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+                match={"type": "contains", "pattern": "acme", "fields": ["counterparty"]},
+                action={"label": "vendor", "category": "biz"})
+    data = {"description": "paycheck", "counterparty": "ACME Corp"}
+    assert evaluate(data, [rule]) == "vendor"
+
+
 def test_evaluate_uses_precedence():
     rules = [
-        Rule(label="low", pattern="shop", priority=1),
-        Rule(label="high", pattern="shop", priority=5),
+        Rule(scope="global", priority=5, version=1, provenance="system", confidence=1.0,
+             match={"type": "contains", "pattern": "shop", "fields": ["description"]},
+             action={"label": "low", "category": "misc"}),
+        Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
+             match={"type": "contains", "pattern": "shop", "fields": ["description"]},
+             action={"label": "high", "category": "misc"}),
     ]
     label = evaluate("coffee shop", merge_rules(rules, []))
     assert label == "high"


### PR DESCRIPTION
## Summary
- adopt full heuristic rule schema with scope, action, match strategy and provenance
- enforce priority→confidence→version/updated_at precedence with user overrides
- expand rules engine tests for schema, match strategies and precedence

## Testing
- `PYTHONPATH=. pytest tests/test_rules_engine.py -q`
- `behave features/rule_engine.feature` *(fails: UserRule object has no attribute 'action')*


------
https://chatgpt.com/codex/tasks/task_e_6890a7a39440832b97014d85e6891a8d