### PR TITLE
Remove unused Callable import from LLM adapter

### DIFF
--- a/backend/llm_adapter.py
+++ b/backend/llm_adapter.py
@@ -8,7 +8,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import date
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove unused Callable from typing imports in LLM adapter

## Testing
- `make lint` *(fails: features/steps/auto_learning_steps.py F401, rules/engine.py E731, tests/test_llm_adapter.py F401)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890bf2a4644832b8020aaede54f109a