### PR TITLE
chore: remove unused import

### DIFF
--- a/features/steps/auto_learning_steps.py
+++ b/features/steps/auto_learning_steps.py
@@ -1,4 +1,3 @@
-import os
 from behave import given, then
 
 from features.steps.backend_api_steps import _setup_client, app


### PR DESCRIPTION
## Summary
- remove unused os import from auto_learning_steps

## Testing
- `make lint` (fails: E731 lambda assignment and unused imports)
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1bbc850832bb2854b253fc0c5e6