### PR TITLE
refactor: use helper function for signature normalization

### DIFF
--- a/rules/engine.py
+++ b/rules/engine.py
@@ -73,6 +73,11 @@ def merge_rules(global_rules: Iterable[Rule], user_rules: Iterable[Rule]) -> Lis
     return sorted(combined.values(), key=_precedence_key)
 
 
+def norm(s: str) -> str:
+    """Normalize a string by stripping non-alphanumeric characters and lowercasing."""
+    return re.sub(r"[^A-Za-z0-9]", "", s).lower()
+
+
 def _match_text(text: str, match: Match) -> bool:
     if match.type == "exact":
         return text == match.pattern
@@ -86,7 +91,6 @@ def _match_text(text: str, match: Match) -> bool:
             flags |= re.MULTILINE
         return re.search(match.pattern, text, flags=flags) is not None
     if match.type == "signature":
-        norm = lambda s: re.sub(r"[^A-Za-z0-9]", "", s).lower()
         return norm(text) == norm(match.pattern)
     return False
 

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,7 +1,6 @@
-import os
 import pytest
 
-from backend.llm_adapter import AbstractAdapter, DailyCostTracker, cost_tracker
+from backend.llm_adapter import AbstractAdapter, DailyCostTracker
 
 
 class DummyAdapter(AbstractAdapter):


### PR DESCRIPTION
## Summary
- replace inline signature normalization lambda with a reusable `norm` helper
- clean up unused imports in LLM adapter tests

## Testing
- `make lint` *(fails: Source file found twice under different module names)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890c93679dc832b828e6b59ee3d1470