### PR TITLE
Remove os import from e2e LLM test

### DIFF
--- a/tests/test_llm_e2e.py
+++ b/tests/test_llm_e2e.py
@@ -1,11 +1,13 @@
-import os
 import pytest
 
 from backend.llm_adapter import OpenAIAdapter
 
 
-@pytest.mark.skipif(not os.getenv("RUN_LLM_E2E"), reason="RUN_LLM_E2E not set")
 def test_openai_e2e():
+    import os
+
+    if not os.getenv("RUN_LLM_E2E"):
+        pytest.skip("RUN_LLM_E2E not set")
     adapter = OpenAIAdapter()
     out = adapter.classify(["hello"], job_id=1)
     assert isinstance(out, list)


### PR DESCRIPTION
## Summary
- clean up LLM e2e test to avoid unnecessary os import
- dynamically skip test when RUN_LLM_E2E not set

## Testing
- `make lint` *(fails: missing stubs and mypy type errors)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890ccd729a0832bb30fe53df1475d80