### PR TITLE
Improve error handling for unsupported bank codes

### DIFF
--- a/bankcleanr/extractor.py
+++ b/bankcleanr/extractor.py
@@ -10,6 +10,12 @@ def extract_transactions(
     pdf_path: str, bank: str = "barclays"
 ) -> List[Dict[str, str | None]]:
     """Extract transactions from a PDF statement using the configured parser."""
-    parser_cls = PARSER_REGISTRY[bank]
+    try:
+        parser_cls = PARSER_REGISTRY[bank]
+    except KeyError as exc:
+        available = ", ".join(sorted(PARSER_REGISTRY))
+        raise ValueError(
+            f"Unsupported bank '{bank}'. Available banks: {available}"
+        ) from exc
     parser = parser_cls()
     return parser.parse(pdf_path)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,13 @@
+import pytest
+
+from bankcleanr.extractor import extract_transactions
+from bankcleanr.parsers import PARSER_REGISTRY
+
+
+def test_extract_transactions_unknown_bank():
+    available = ", ".join(sorted(PARSER_REGISTRY))
+    with pytest.raises(ValueError) as excinfo:
+        extract_transactions("dummy.pdf", bank="unknown")
+    assert str(excinfo.value) == (
+        f"Unsupported bank 'unknown'. Available banks: {available}"
+    )


### PR DESCRIPTION
## Summary
- handle unknown bank codes in `extract_transactions` by raising `ValueError` listing available parser keys
- add unit test covering unsupported bank code behaviour

## Testing
- `PYTHONPATH=$PWD pytest tests/test_extractor.py tests/test_parsers.py -q`
- `PYTHONPATH=$PWD behave features/extract_barclays.feature -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_689247330f70832b94e70c8548e88ce0