### PR TITLE
Allow user rules to override global by pattern

### DIFF
--- a/rules/engine.py
+++ b/rules/engine.py
@@ -61,14 +61,14 @@ def _precedence_key(rule: Rule):
 
 def merge_rules(global_rules: Iterable[Rule], user_rules: Iterable[Rule]) -> List[Rule]:
     """Merge global and user rules applying precedence and overrides."""
-    combined: dict[tuple[str, str], Rule] = {}
+    combined: dict[tuple[str, tuple[str, ...]], Rule] = {}
     for rule in global_rules:
-        key = (rule.action.label, rule.match.pattern)
+        key = (rule.match.pattern, tuple(sorted(rule.match.fields)))
         existing = combined.get(key)
         if not existing or _precedence_key(rule) < _precedence_key(existing):
             combined[key] = rule
     for rule in user_rules:
-        key = (rule.action.label, rule.match.pattern)
+        key = (rule.match.pattern, tuple(sorted(rule.match.fields)))
         combined[key] = rule
     return sorted(combined.values(), key=_precedence_key)
 

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -26,6 +26,17 @@ def test_user_rule_overrides_global():
     assert merged[0].scope == "user"
 
 
+def test_user_rule_overrides_global_with_different_label():
+    g = [_base_rule(match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
+                    action={"label": "global", "category": "drink"})]
+    u = [Rule(scope="user", owner_user_id="1", priority=0, version=1, provenance="user", confidence=1.0,
+             match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
+             action={"label": "user", "category": "drink"})]
+    merged = merge_rules(g, u)
+    assert len(merged) == 1
+    assert merged[0].action.label == "user"
+
+
 def test_precedence_priority_confidence_version_updated():
     now = datetime.utcnow()
     earlier = now - timedelta(days=1)


### PR DESCRIPTION
## Summary
- Merge rules using pattern and field instead of label and pattern
- Test that user rule overrides global rule with same pattern but different label

## Testing
- `PYTHONPATH=. pytest tests/test_rules_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68925143d1f8832bb1522bcfc81d7a36