### PR TITLE
Refine signature normalisation

### DIFF
--- a/bankcleanr/signature.py
+++ b/bankcleanr/signature.py
@@ -12,11 +12,17 @@ _PREFIXES: tuple[str, ...] = (
     "card",
     "payment",
     "purchase",
+    "dd",
+    "so",
+    "sto",
+    "tfr",
 )
 
 _SUFFIXES: tuple[str, ...] = (
     "uk",
     "gb",
+    "co",
+    "ltd",
 )
 
 
@@ -32,6 +38,13 @@ def _remove_tokens(text: str, tokens: Iterable[str], *, prefix: bool) -> str:
         elif not prefix and text.endswith(" " + token):
             text = text[: -(len(token) + 1)]
     return text
+
+
+def _trim_trailing_digits(text: str, *, min_length: int = 5) -> str:
+    tokens = text.split()
+    while tokens and tokens[-1].isdigit() and len(tokens[-1]) >= min_length:
+        tokens.pop()
+    return " ".join(tokens)
 
 
 def normalise_signature(text: str) -> str:
@@ -53,7 +66,7 @@ def normalise_signature(text: str) -> str:
     text = re.sub(r"\s+", " ", text).strip()
     text = _remove_tokens(text, _PREFIXES, prefix=True)
     text = _remove_tokens(text, _SUFFIXES, prefix=False)
-    text = re.sub(r"\b\d+\b", "", text)
+    text = _trim_trailing_digits(text)
     text = re.sub(r"\s+", " ", text).strip()
     return text
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,16 @@
+from bankcleanr.signature import normalise_signature
+
+
+def test_diacritics_are_removed():
+    assert normalise_signature("Café Métro") == "cafe metro"
+
+
+def test_prefixes_and_suffixes():
+    assert normalise_signature("dd Example ltd") == "example"
+    assert normalise_signature("sto Sample co") == "sample"
+
+
+def test_trailing_digits_trimmed():
+    assert normalise_signature("merchant 123456 78910") == "merchant"
+    assert normalise_signature("merchant 1234") == "merchant 1234"
+    assert normalise_signature("123456 merchant") == "123456 merchant"


### PR DESCRIPTION
## Summary
- handle trailing numeric tokens >=5 digits when normalising signatures
- broaden prefix/suffix lists for signature cleanup
- add tests for diacritics, token trimming and numeric removal

## Testing
- `poetry run ruff check bankcleanr/signature.py tests/test_signature.py`
- `poetry run mypy bankcleanr/signature.py tests/test_signature.py`
- `poetry run pytest -q`
- `OPENAI_API_KEY=dummy poetry run behave -q`

------
https://chatgpt.com/codex/tasks/task_e_689281162124832b8547c2c1bfada7d6