### PR TITLE
Track LLM usage costs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from .models import (
     UserRule,
     ClassificationResult,
     ClassifyRequest,
+    LLMCost,
 )
 from rules.engine import load_global_rules, merge_rules, evaluate, Rule
 from backend.llm_adapter import get_adapter, AbstractAdapter

--- a/backend/models.py
+++ b/backend/models.py
@@ -35,6 +35,14 @@ class ClassificationResult(SQLModel, table=True):
     status: str = Field(default="queued")
 
 
+class LLMCost(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    job_id: int = Field(foreign_key="processingjob.id")
+    tokens_in: int = 0
+    tokens_out: int = 0
+    estimated_cost_gbp: float
+
+
 class ClassifyRequest(SQLModel):
     job_id: int
     user_id: int = 0

--- a/features/steps/backend_api_steps.py
+++ b/features/steps/backend_api_steps.py
@@ -10,6 +10,7 @@ from behave import given, when, then
 from backend.app import app
 from backend.database import get_session
 from backend.signing import generate_signed_url
+import backend.llm_adapter as llm_adapter
 
 
 def _setup_client(context):
@@ -22,6 +23,7 @@ def _setup_client(context):
             yield session
 
     app.dependency_overrides[get_session] = get_session_override
+    llm_adapter.get_session = get_session_override
     context.client = TestClient(app)
 
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -15,7 +15,7 @@ from backend.signing import generate_signed_url
 
 
 @pytest.fixture(name="client")
-def client_fixture():
+def client_fixture(monkeypatch):
     os.environ["AUTH_BYPASS"] = "1"
     engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
     SQLModel.metadata.create_all(engine)
@@ -40,6 +40,7 @@ def client_fixture():
 
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_adapter] = adapter_override
+    monkeypatch.setattr("backend.llm_adapter.get_session", get_session_override)
     with TestClient(app) as c:
         c.adapter = dummy_adapter
         yield c


### PR DESCRIPTION
## Summary
- add `LLMCost` model to persist token usage and cost data
- log token counts and estimated cost in `DailyCostTracker`
- test cost persistence and daily limit handling

## Testing
- `PYTHONPATH=$PWD pytest tests/test_llm_adapter.py tests/test_backend_api.py -q`
- `PYTHONPATH=$PWD behave features/extract_barclays.feature -q` *(fails: ModuleNotFoundError: typer)*


------
https://chatgpt.com/codex/tasks/task_e_689333d22114832b8a91f09fc78a0850