### PR TITLE
chore: remove unused LLMCost import

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,6 @@ from .models import (
     UserRule,
     ClassificationResult,
     ClassifyRequest,
-    LLMCost,
 )
 from rules.engine import load_global_rules, merge_rules, evaluate, Rule, norm
 from backend.llm_adapter import get_adapter, AbstractAdapter


### PR DESCRIPTION
## Summary
- remove unused LLMCost import from backend app

## Testing
- `make lint` *(fails: Library stubs not installed for "jsonschema"; Source file found twice under different module names)*
- `make test` *(fails: tests/test_backend_api.py::test_rules)*
- `poetry run behave` *(fails: rule_auto_learning.feature scenario)*

------
https://chatgpt.com/codex/tasks/task_e_689245e27f18832b946ed123cbe381a6