### PR TITLE
Configure mypy explicit package bases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ pytest-asyncio = "^0.23.6"
 [tool.poetry.scripts]
 bankcleanr = "bankcleanr.cli:app"
 
+[tool.mypy]
+explicit_package_bases = true
+packages = ["backend", "bankcleanr", "rules"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure mypy with explicit package bases for backend, bankcleanr, and rules packages

## Testing
- `make lint` *(fails: mypy type errors, but no 'Source file found twice' message)*
- `make test` *(fails: tests/test_backend_api.py::test_rules, coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_6893556b4aec832bac68b37eab4ca158