### PR TITLE
Add LLM-based report generation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, Depends, Request, HTTPException, Query
 from fastapi.responses import FileResponse
+from .report import router as report_router
 from sqlmodel import Session, select
 from .database import init_db, get_session
 from .auth import auth_dependency
@@ -29,6 +30,7 @@ ALLOWED_CONTENT_TYPES = {"application/x-ndjson", "text/plain"}
 GLOBAL_RULES: list[Rule] = []
 SIGNATURE_CACHE: dict[str, dict] = {}
 
+app.include_router(report_router)
 
 def _convert_user_rule(rule: UserRule) -> Rule:
     return Rule(

--- a/backend/report.py
+++ b/backend/report.py
@@ -1,0 +1,96 @@
+"""Report generation using LLM and WeasyPrint."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from typing import Callable, Union
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
+
+from .auth import auth_dependency
+
+# Type alias for LLM callable which takes prompt string and returns
+# either HTML string or PDF bytes
+LLMFunc = Callable[[str], Union[str, bytes]]
+
+router = APIRouter()
+
+
+def get_llm() -> LLMFunc:
+    """Return a callable that sends a prompt to an LLM."""
+    import openai
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = openai.OpenAI(api_key=api_key)
+    model = os.getenv("REPORT_MODEL", "gpt-4o-mini")
+
+    def _call(prompt: str) -> str:
+        resp = client.chat.completions.create(
+            model=model, messages=[{"role": "user", "content": prompt}]
+        )
+        return resp.choices[0].message.content or ""
+
+    return _call
+
+
+def _summary_path(job_id: int) -> Path:
+    storage_dir = Path(os.environ.get("STORAGE_DIR", "./storage"))
+    return storage_dir / f"{job_id}_summary_v1.json"
+
+
+def _report_path(job_id: int) -> Path:
+    storage_dir = Path(os.environ.get("STORAGE_DIR", "./storage"))
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    return storage_dir / f"{job_id}_report.pdf"
+
+
+def generate_report(job_id: int, llm: LLMFunc) -> Path:
+    """Generate a PDF report for the given job using the provided LLM."""
+    summary_file = _summary_path(job_id)
+    if not summary_file.exists():
+        raise FileNotFoundError("Summary not found")
+    prompt = summary_file.read_text(encoding="utf-8")
+
+    def _call() -> Union[str, bytes]:
+        return llm(prompt)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(_call)
+            content = future.result(timeout=30)
+    except FutureTimeout as exc:  # pragma: no cover - timeout scenario
+        raise RuntimeError("Report generation timed out") from exc
+
+    if isinstance(content, bytes) and content.startswith(b"%PDF"):
+        pdf_bytes = content
+    else:
+        from weasyprint import HTML
+
+        html_str = content.decode("utf-8") if isinstance(content, bytes) else str(content)
+        pdf_bytes = HTML(string=html_str).write_pdf()
+
+    if len(pdf_bytes) > 5 * 1024 * 1024:
+        raise RuntimeError("Generated PDF too large")
+
+    pdf_path = _report_path(job_id)
+    pdf_path.write_bytes(pdf_bytes)
+    return pdf_path
+
+
+@router.get("/report/{job_id}")
+def get_report(job_id: int, llm: LLMFunc = Depends(get_llm), _: None = Depends(auth_dependency)):
+    """Return the report PDF for the given job ID, generating it if necessary."""
+    path = _report_path(job_id)
+    if not path.exists():
+        try:
+            path = generate_report(job_id, llm)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Summary not found")
+        except RuntimeError as exc:  # pragma: no cover - error cases
+            raise HTTPException(status_code=500, detail=str(exc))
+    return FileResponse(path, media_type="application/pdf")
+
+
+__all__ = ["router", "get_llm", "generate_report"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ fastapi = "^0.111.0"
 sqlmodel = "^0.0.16"
 uvicorn = "^0.30.0"
 rapidfuzz = "^3.6.1"
+weasyprint = "^62.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,71 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine
+
+from backend.app import app
+from backend.report import get_llm
+from backend.database import get_session
+
+
+@pytest.fixture(name="client")
+def client_fixture(tmp_path: Path, monkeypatch):
+    os.environ["AUTH_BYPASS"] = "1"
+    os.environ["STORAGE_DIR"] = str(tmp_path)
+
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    SQLModel.metadata.create_all(engine)
+
+    def get_session_override():
+        with Session(engine) as session:
+            yield session
+
+    def dummy_llm(prompt: str) -> str:
+        return "<html><body><h1>Report</h1></body></html>"
+
+    app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_llm] = lambda: dummy_llm
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+    os.environ.pop("AUTH_BYPASS", None)
+    os.environ.pop("STORAGE_DIR", None)
+
+
+def _create_job(client: TestClient) -> int:
+    resp = client.post("/upload", data="data", headers={"Content-Type": "text/plain"})
+    return resp.json()["job_id"]
+
+
+def test_report_generation(client: TestClient, tmp_path: Path):
+    job_id = _create_job(client)
+    summary = {
+        "job_id": str(job_id),
+        "user_id": "1",
+        "period": {"start": "2024-01-01", "end": "2024-01-31"},
+        "currency": "GBP",
+        "totals": {"income": 0, "expenses": 0, "net": 0},
+        "categories": [],
+    }
+    summary_path = Path(os.environ["STORAGE_DIR"]) / f"{job_id}_summary_v1.json"
+    summary_path.write_text(json.dumps(summary))
+
+    resp = client.get(f"/report/{job_id}")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+
+    pdf_path = Path(os.environ["STORAGE_DIR"]) / f"{job_id}_report.pdf"
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size < 5 * 1024 * 1024
+
+
+def test_report_missing_summary(client: TestClient):
+    job_id = _create_job(client)
+    resp = client.get(f"/report/{job_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add report generator that prompts LLM with job summary and produces PDF via WeasyPrint
- expose `/report/{job_id}` endpoint and include WeasyPrint dependency
- create tests for report generation and missing summary handling

## Testing
- `ruff check backend/report.py tests/test_report.py`
- `PYTHONPATH=. pytest tests/test_report.py`
- `behave` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893900c4eac832b9762c523052d5d2c