### PR TITLE
Add multi-platform build workflow and release docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            artifact: bankcleanr-macos-intel
+            macos_arch: x86_64
+            ext: ""
+          - os: macos-latest
+            artifact: bankcleanr-macos-arm
+            macos_arch: arm64
+            ext: ""
+          - os: windows-latest
+            artifact: bankcleanr-windows
+            macos_arch: ""
+            ext: ".exe"
+          - os: ubuntu-latest
+            artifact: bankcleanr-linux
+            macos_arch: ""
+            ext: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --only main
+      - name: Build executable
+        run: poetry run bankcleanr.cli build
+        env:
+          MACOS_ARCH: ${{ matrix.macos_arch }}
+      - name: Prepare artifact (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          mv dist/bankcleanr dist/${{ matrix.artifact }}
+          cd dist
+          shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+      - name: Prepare artifact (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Rename-Item dist/bankcleanr.exe "${{ matrix.artifact }}.exe"
+          $hash = Get-FileHash "dist\${{ matrix.artifact }}.exe" -Algorithm SHA256
+          "$($hash.Hash)  $($hash.Path | Split-Path -Leaf)" | Out-File -Encoding utf8 "dist\${{ matrix.artifact }}.sha256"
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            dist/${{ matrix.artifact }}${{ matrix.ext }}
+            dist/${{ matrix.artifact }}.sha256

--- a/README.md
+++ b/README.md
@@ -285,6 +285,33 @@ On Windows use the `.exe` produced in the `dist/windows` directory:
 dist\windows\bankcleanr.exe parse "Redacted bank statements\22b583f5-4060-44eb-a844-945cd612353c (1).pdf" --jsonl tx.jsonl
 ```
 
+## Release process
+
+1. Update the version in `pyproject.toml` and commit the change.
+2. Create a new tag and push it to GitHub:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The `build` workflow builds executables for Linux, macOS (Intel and ARM) and Windows. Each job uploads its binary and a matching `.sha256` checksum file to the GitHub release associated with the tag.
+
+### Verifying checksums
+
+After downloading an executable and its checksum file, confirm the contents match:
+
+```bash
+# macOS / Linux
+shasum -a 256 -c bankcleanr-linux.sha256
+
+# Windows (PowerShell)
+CertUtil -hashfile bankcleanr-windows.exe SHA256
+Get-Content bankcleanr-windows.exe.sha256
+```
+
+The displayed hash must equal the value stored in the `.sha256` file before running the binary.
+
 ## Disclaimer
 
 Every summary includes the following disclaimer:


### PR DESCRIPTION
## Summary
- add build workflow to produce tagged binaries across platforms and upload to releases
- document release process and checksum verification

## Testing
- `poetry run pytest` *(failed: tests/test_backend_api.py::test_rules)*
- `poetry run behave` *(hung waiting for input: Enter comma-separated names to mask)*

------
https://chatgpt.com/codex/tasks/task_e_6893c0cc3b0c832ba76c421aa492b049