### PR TITLE
Add LLM provider registry with cost tracking

### DIFF
--- a/features/llm_adapter.feature
+++ b/features/llm_adapter.feature
@@ -1,0 +1,5 @@
+Feature: LLM provider selection
+  Scenario: Select Anthropic adapter using environment variable
+    Given the environment variable LLM_PROVIDER is set to "anthropic"
+    When requesting an LLM adapter
+    Then the adapter type is "AnthropicAdapter"

--- a/features/steps/llm_adapter_steps.py
+++ b/features/steps/llm_adapter_steps.py
@@ -1,0 +1,20 @@
+import os
+from behave import given, when, then
+import backend.llm_adapter as llm_adapter
+
+
+@given('the environment variable LLM_PROVIDER is set to "{provider}"')
+def set_provider(context, provider):
+    os.environ["LLM_PROVIDER"] = provider
+    llm_adapter._adapter_instances.clear()
+
+
+@when("requesting an LLM adapter")
+def request_adapter(context):
+    context.adapter = llm_adapter.get_adapter()
+
+
+@then('the adapter type is "{cls_name}"')
+def check_adapter_type(context, cls_name):
+    cls = getattr(llm_adapter, cls_name)
+    assert isinstance(context.adapter, cls)


### PR DESCRIPTION
## Summary
- refactor `llm_adapter` into a registry supporting OpenAI, Anthropic and Azure providers
- track and log per-report LLM usage with a £5 cap
- add unit and BDD tests for provider selection and cost limits

## Testing
- `pytest tests/test_llm_adapter.py`
- `behave features/llm_adapter.feature`


------
https://chatgpt.com/codex/tasks/task_e_6893ce79e3d8832bae4d86ce346d7044