### PR TITLE
Parse ISO dates and mask names

### DIFF
--- a/bankcleanr/parsers/barclays.py
+++ b/bankcleanr/parsers/barclays.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 from typing import Dict, List
+from datetime import datetime
+from decimal import Decimal
 
 import pdfplumber
 
@@ -28,10 +30,10 @@ class BarclaysParser:
                         clean_desc = mask_pii(desc.strip())
                         records.append(
                             {
-                                "date": date,
+                                "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
-                                "amount": amount,
-                                "balance": balance,
+                                "amount": f"{Decimal(amount):+.2f}",
+                                "balance": f"{Decimal(balance):+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                             }
                         )

--- a/bankcleanr/parsers/hsbc.py
+++ b/bankcleanr/parsers/hsbc.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 from typing import Dict, List
+from datetime import datetime
+from decimal import Decimal
 
 import pdfplumber
 
@@ -28,10 +30,10 @@ class HSBCParser:
                         clean_desc = mask_pii(desc.strip())
                         records.append(
                             {
-                                "date": date,
+                                "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
-                                "amount": amount,
-                                "balance": balance,
+                                "amount": f"{Decimal(amount):+.2f}",
+                                "balance": f"{Decimal(balance):+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                             }
                         )

--- a/bankcleanr/parsers/lloyds.py
+++ b/bankcleanr/parsers/lloyds.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 from typing import Dict, List
+from datetime import datetime
+from decimal import Decimal
 
 import pdfplumber
 
@@ -28,10 +30,10 @@ class LloydsParser:
                         clean_desc = mask_pii(desc.strip())
                         records.append(
                             {
-                                "date": date,
+                                "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
-                                "amount": amount,
-                                "balance": balance,
+                                "amount": f"{Decimal(amount):+.2f}",
+                                "balance": f"{Decimal(balance):+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                             }
                         )

--- a/bankcleanr/parsers/placeholder.py
+++ b/bankcleanr/parsers/placeholder.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from typing import Dict, List
+from datetime import datetime
+from decimal import Decimal
 
 from ..signature import normalise_signature
 
@@ -11,10 +13,10 @@ class PlaceholderParser:
     def parse(self, pdf_path: str) -> List[Dict[str, str | None]]:  # noqa: D401
         return [
             {
-                "date": "01 Jan 2024",
+                "date": datetime.strptime("01 Jan 2024", "%d %b %Y").date().isoformat(),
                 "description": "placeholder",
-                "amount": "0.00",
-                "balance": "0.00",
+                "amount": f"{Decimal('0.00'):+.2f}",
+                "balance": f"{Decimal('0.00'):+.2f}",
                 "merchant_signature": normalise_signature("placeholder"),
             }
         ]

--- a/bankcleanr/pii.py
+++ b/bankcleanr/pii.py
@@ -9,6 +9,7 @@ from rapidfuzz import fuzz
 _SORT_CODE_RE = re.compile(r"\b\d{2}-\d{2}-\d{2}\b")
 _IBAN_RE = re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{10,}\b")
 _PAN_RE = re.compile(r"\b\d{12,19}\b")
+_NAME_RE = re.compile(r"\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+\b")
 
 _MASKED_NAME = "XX MASKED NAME XX"
 
@@ -65,9 +66,14 @@ def _mask_names(text: str, names: Iterable[str], threshold: int = 85) -> str:
     return text
 
 
+def mask_names(text: str) -> str:
+    """Mask names detected in ``text`` using a simple heuristic."""
+    return _NAME_RE.sub(_MASKED_NAME, text)
+
+
 def mask_pii(text: str, names: Iterable[str] | None = None) -> str:
     """Mask common PII patterns and supplied names in the given text."""
-    for masker in (_mask_sort_code, _mask_iban, _mask_pan):
+    for masker in (_mask_sort_code, _mask_iban, _mask_pan, mask_names):
         text = masker(text)
     if names:
         text = _mask_names(text, names)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import tempfile
 
 import pytest
@@ -62,3 +63,6 @@ def test_extract_transactions(bank, expected):
         assert len(records) == expected
         for rec in records:
             jsonschema.validate(rec, SCHEMA)
+            assert re.match(r"^\d{4}-\d{2}-\d{2}$", rec["date"])
+            assert re.match(r"^[+-]\d+\.\d{2}$", rec["amount"])
+        assert any(r["amount"].startswith("+") for r in records)

--- a/tests/test_pii.py
+++ b/tests/test_pii.py
@@ -1,4 +1,4 @@
-from bankcleanr.pii import mask_pii
+from bankcleanr.pii import mask_pii, mask_names
 
 
 def test_mask_sort_code():
@@ -15,8 +15,12 @@ def test_mask_pan():
     assert masked == "card XXXXXXXXXXXX3456"
 
 
-def test_mask_name_exact():
-    masked = mask_pii("Paid to John Doe", ["John Doe"])
+def test_mask_names_helper():
+    assert mask_names("John Doe went") == "XX MASKED NAME XX went"
+
+
+def test_mask_name_auto():
+    masked = mask_pii("Paid to John Doe")
     assert masked == "Paid to XX MASKED NAME XX"
 
 


### PR DESCRIPTION
## Summary
- parse transaction dates using datetime.strptime and emit ISO format
- format amounts and balances as signed Decimal strings
- add name masking helper and test coverage for name masking

## Testing
- `poetry run pytest` *(fails: assert False in tests/test_backend_api.py::test_rules)*
- `behave` *(aborted: KeyboardInterrupt)*
- `make e2e` *(fails: docker-compose: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d0fe206c832bbfe57a74e52d3078