### PR TITLE
docs: fix Windows checksum filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ shasum -a 256 -c bankcleanr-linux.sha256
 
 # Windows (PowerShell)
 CertUtil -hashfile bankcleanr-windows.exe SHA256
-Get-Content bankcleanr-windows.exe.sha256
+Get-Content bankcleanr-windows.sha256
 ```
 
 The displayed hash must equal the value stored in the `.sha256` file before running the binary.


### PR DESCRIPTION
## Summary
- fix Windows checksum filename in README verifying checksums section

## Testing
- `poetry run pytest` *(fails: tests/test_backend_api.py::test_rules - assert False)*
- `poetry run behave` *(aborted: user input prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6894cb556c04832b9d344a2396b28708