### PR TITLE
chore: pin release action to commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,10 @@ jobs:
           $hash = Get-FileHash "dist\${{ matrix.artifact }}.exe" -Algorithm SHA256
           "$($hash.Hash)  $($hash.Path | Split-Path -Leaf)" | Out-File -Encoding utf8 "dist\${{ matrix.artifact }}.sha256"
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
         with:
           tag_name: ${{ github.ref_name }}
+          fail_on_unmatched_files: true
           files: |
             dist/${{ matrix.artifact }}${{ matrix.ext }}
             dist/${{ matrix.artifact }}.sha256


### PR DESCRIPTION
## Summary
- pin `softprops/action-gh-release` to specific commit
- enable checking for missing artifacts in release step

## Testing
- `make test` *(fails: Required test coverage of 90% not reached. Total coverage: 81.65%; tests/test_backend_api.py::test_rules failed)*
- `make component` *(fails: tests/test_backend_api.py::test_rules - assert False)*

------
https://chatgpt.com/codex/tasks/task_e_6894cff04dcc832b83620dbe1ad74667