### PR TITLE
feat: add PDF report generation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -114,11 +114,13 @@ def download(
         raise HTTPException(status_code=403, detail="Invalid or expired URL")
 
     storage_dir = Path(os.environ.get("STORAGE_DIR", "./storage"))
-    file_path = storage_dir / f"{job_id}_{type}.txt"
+    ext = "pdf" if type == "report" else "txt"
+    file_path = storage_dir / f"{job_id}_{type}.{ext}"
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
 
-    return FileResponse(file_path)
+    media_type = "application/pdf" if type == "report" else "text/plain"
+    return FileResponse(file_path, media_type=media_type)
 
 
 @app.get("/rules")

--- a/backend/report.py
+++ b/backend/report.py
@@ -4,33 +4,46 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
-from typing import Callable, Union
+from typing import Callable, Tuple, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import FileResponse
 
 from .auth import auth_dependency
+from .signing import generate_signed_url
+from backend.llm_adapter import cost_tracker
 
-# Type alias for LLM callable which takes prompt string and returns
-# either HTML string or PDF bytes
-LLMFunc = Callable[[str], Union[str, bytes]]
+from weasyprint import HTML, CSS
+
+# LLM callable returning generated HTML and usage statistics
+LLMFunc = Callable[[str], Tuple[str, Dict[str, int]]]
+
+# Accessible A4 stylesheet used by WeasyPrint
+A4_CSS = """
+@page { size: A4; margin: 2cm; }
+body { font-family: Arial, sans-serif; }
+"""
 
 router = APIRouter()
 
 
 def get_llm() -> LLMFunc:
-    """Return a callable that sends a prompt to an LLM."""
+    """Return a callable that sends a prompt to an LLM and returns HTML and usage."""
     import openai
 
     api_key = os.getenv("OPENAI_API_KEY")
     client = openai.OpenAI(api_key=api_key)
     model = os.getenv("REPORT_MODEL", "gpt-4o-mini")
 
-    def _call(prompt: str) -> str:
+    def _call(prompt: str) -> Tuple[str, Dict[str, int]]:
         resp = client.chat.completions.create(
             model=model, messages=[{"role": "user", "content": prompt}]
         )
-        return resp.choices[0].message.content or ""
+        usage = getattr(resp, "usage", {})
+        content = resp.choices[0].message.content or ""
+        return content, {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+        }
 
     return _call
 
@@ -53,23 +66,26 @@ def generate_report(job_id: int, llm: LLMFunc) -> Path:
         raise FileNotFoundError("Summary not found")
     prompt = summary_file.read_text(encoding="utf-8")
 
-    def _call() -> Union[str, bytes]:
+    def _call() -> Tuple[str, Dict[str, int]]:
         return llm(prompt)
 
     try:
         with ThreadPoolExecutor(max_workers=1) as ex:
             future = ex.submit(_call)
-            content = future.result(timeout=30)
+            content, usage = future.result(timeout=30)
     except FutureTimeout as exc:  # pragma: no cover - timeout scenario
         raise RuntimeError("Report generation timed out") from exc
 
-    if isinstance(content, bytes) and content.startswith(b"%PDF"):
-        pdf_bytes = content
-    else:
-        from weasyprint import HTML
+    tokens_in = usage.get("prompt_tokens", usage.get("total_tokens", 0))
+    tokens_out = usage.get("completion_tokens", 0)
+    tokens = tokens_in + tokens_out
+    price_per_1k = float(os.getenv("PRICE_PER_1K_TOKENS_GBP", "0.002"))
+    cost = tokens / 1000 * price_per_1k
+    cost_tracker.add(job_id, tokens_in, tokens_out, cost)
 
-        html_str = content.decode("utf-8") if isinstance(content, bytes) else str(content)
-        pdf_bytes = HTML(string=html_str).write_pdf()
+    html_str = content if isinstance(content, str) else str(content)
+    css = CSS(string=A4_CSS)
+    pdf_bytes = HTML(string=html_str).write_pdf(stylesheets=[css])
 
     if len(pdf_bytes) > 5 * 1024 * 1024:
         raise RuntimeError("Generated PDF too large")
@@ -81,7 +97,7 @@ def generate_report(job_id: int, llm: LLMFunc) -> Path:
 
 @router.get("/report/{job_id}")
 def get_report(job_id: int, llm: LLMFunc = Depends(get_llm), _: None = Depends(auth_dependency)):
-    """Return the report PDF for the given job ID, generating it if necessary."""
+    """Generate a report PDF and return a signed download URL."""
     path = _report_path(job_id)
     if not path.exists():
         try:
@@ -90,7 +106,9 @@ def get_report(job_id: int, llm: LLMFunc = Depends(get_llm), _: None = Depends(a
             raise HTTPException(status_code=404, detail="Summary not found")
         except RuntimeError as exc:  # pragma: no cover - error cases
             raise HTTPException(status_code=500, detail=str(exc))
-    return FileResponse(path, media_type="application/pdf")
+
+    url = generate_signed_url(f"/download/{job_id}/report")
+    return {"url": url}
 
 
 __all__ = ["router", "get_llm", "generate_report"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,11 +5,27 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
-from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel import SQLModel, Session, create_engine, select
 
 from backend.app import app
+from backend import report
 from backend.report import get_llm
 from backend.database import get_session
+from backend.models import LLMCost
+from backend.llm_adapter import DailyCostTracker
+
+
+class DummyHTML:
+    def __init__(self, string: str):
+        self.string = string
+
+    def write_pdf(self, stylesheets=None):
+        return b"%PDF-1.4\n%%EOF"
+
+
+class DummyCSS:
+    def __init__(self, string: str):
+        self.string = string
 
 
 @pytest.fixture(name="client")
@@ -17,21 +33,34 @@ def client_fixture(tmp_path: Path, monkeypatch):
     os.environ["AUTH_BYPASS"] = "1"
     os.environ["STORAGE_DIR"] = str(tmp_path)
 
-    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     SQLModel.metadata.create_all(engine)
 
     def get_session_override():
         with Session(engine) as session:
             yield session
 
-    def dummy_llm(prompt: str) -> str:
-        return "<html><body><h1>Report</h1></body></html>"
+    def dummy_llm(prompt: str):
+        return "<html><body>Report</body></html>", {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+        }
+
+    tracker = DailyCostTracker(limit=1.0)
+    monkeypatch.setattr("backend.llm_adapter.cost_tracker", tracker)
+    monkeypatch.setattr("backend.llm_adapter.get_session", get_session_override)
+    monkeypatch.setattr(report, "HTML", DummyHTML)
+    monkeypatch.setattr(report, "CSS", DummyCSS)
 
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_llm] = lambda: dummy_llm
 
     with TestClient(app) as c:
-        yield c
+        yield c, engine
 
     app.dependency_overrides.clear()
     os.environ.pop("AUTH_BYPASS", None)
@@ -43,8 +72,9 @@ def _create_job(client: TestClient) -> int:
     return resp.json()["job_id"]
 
 
-def test_report_generation(client: TestClient, tmp_path: Path):
-    job_id = _create_job(client)
+def test_report_generation(client: tuple[TestClient, any], tmp_path: Path):
+    client_obj, engine = client
+    job_id = _create_job(client_obj)
     summary = {
         "job_id": str(job_id),
         "user_id": "1",
@@ -56,16 +86,27 @@ def test_report_generation(client: TestClient, tmp_path: Path):
     summary_path = Path(os.environ["STORAGE_DIR"]) / f"{job_id}_summary_v1.json"
     summary_path.write_text(json.dumps(summary))
 
-    resp = client.get(f"/report/{job_id}")
+    resp = client_obj.get(f"/report/{job_id}")
     assert resp.status_code == 200
-    assert resp.headers["content-type"] == "application/pdf"
+    url = resp.json()["url"]
+
+    download = client_obj.get(url)
+    assert download.status_code == 200
+    assert download.headers["content-type"] == "application/pdf"
 
     pdf_path = Path(os.environ["STORAGE_DIR"]) / f"{job_id}_report.pdf"
     assert pdf_path.exists()
-    assert pdf_path.stat().st_size < 5 * 1024 * 1024
+
+    with Session(engine) as session:
+        entry = session.exec(select(LLMCost)).one()
+        assert entry.job_id == job_id
+        assert entry.tokens_in == 10
+        assert entry.tokens_out == 5
+        assert entry.estimated_cost_gbp > 0
 
 
-def test_report_missing_summary(client: TestClient):
-    job_id = _create_job(client)
-    resp = client.get(f"/report/{job_id}")
+def test_report_missing_summary(client: tuple[TestClient, any]):
+    client_obj, _ = client
+    job_id = _create_job(client_obj)
+    resp = client_obj.get(f"/report/{job_id}")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- generate accessible A4 PDF reports via WeasyPrint and record LLM cost
- serve reports through signed URLs using a new `/report/{job_id}` endpoint
- support PDF downloads via existing `/download` route and add unit tests

## Testing
- `PYTHONPATH=. pytest tests/test_report.py tests/test_backend_api.py::test_download -q`


------
https://chatgpt.com/codex/tasks/task_e_68952d7e43fc832bb65f345d966598fc