### PR TITLE
Validate rule categories against taxonomy

### DIFF
--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -28,6 +28,22 @@ def load_categories(path: Path = CATEGORIES_PATH) -> List[str]:
         return json.load(f)
 
 
+def validate_rule_categories(
+    rules: Iterable[Dict[str, Any] | Any], categories: Optional[List[str]] = None
+) -> None:
+    """Ensure rules use categories from the sanctioned taxonomy."""
+    categories_set = set(categories or load_categories())
+
+    def _cat(rule: Any) -> str:
+        if isinstance(rule, dict):
+            return rule.get("action", {}).get("category")
+        return getattr(rule.action, "category", None)
+
+    unknown = {c for r in rules if (c := _cat(r)) not in categories_set}
+    if unknown:
+        raise ValueError(f"Unknown categories: {sorted(unknown)}")
+
+
 def compute_monthly_totals(transactions: Iterable[Dict[str, Any]]) -> Dict[str, float]:
     """Aggregate transaction amounts per YYYY-MM."""
     totals: Dict[str, float] = defaultdict(float)

--- a/component_overview.md
+++ b/component_overview.md
@@ -78,3 +78,12 @@ the extractor for Windows and macOS, while section 9 mentions signed builds:
 > **Signed builds** – follow `component_overview.md` for macOS notarisation & Windows EV cert.
 
 This document fulfils those references by detailing the required steps.
+
+## Category Taxonomy
+
+Transaction classification across the project relies on a shared taxonomy
+defined in `data/taxonomy/categories.json`. The file lists sanctioned
+categories such as Income, Housing and Utilities. Both the rules engine and the
+analytics utilities load this list and validate that every rule uses one of the
+approved categories. When introducing new categories update the JSON file and
+ensure the taxonomy tests continue to pass.

--- a/rules/heuristic_rule_v1.json
+++ b/rules/heuristic_rule_v1.json
@@ -16,7 +16,7 @@
     },
     "action": {
       "label": "coffee",
-      "category": "drink"
+      "category": "Groceries"
     }
   },
   {
@@ -36,7 +36,7 @@
     },
     "action": {
       "label": "tea",
-      "category": "drink"
+      "category": "Groceries"
     }
   }
 ]

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -11,27 +11,27 @@ def _base_rule(**kwargs):
         "provenance": "system",
         "confidence": 1.0,
         "match": {"type": "contains", "pattern": "x", "fields": ["description"]},
-        "action": {"label": "x", "category": "misc"},
+        "action": {"label": "x", "category": "Utilities"},
     }
     base.update(kwargs)
     return Rule(**base)
 
 
 def test_user_rule_overrides_global():
-    g = [_base_rule(match={"type": "contains", "pattern": "coffee", "fields": ["description"]}, action={"label": "coffee", "category": "drink"})]
+    g = [_base_rule(match={"type": "contains", "pattern": "coffee", "fields": ["description"]}, action={"label": "coffee", "category": "Groceries"})]
     u = [Rule(scope="user", owner_user_id="1", priority=0, version=1, provenance="user", confidence=1.0,
              match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
-             action={"label": "coffee", "category": "drink"})]
+             action={"label": "coffee", "category": "Groceries"})]
     merged = merge_rules(g, u)
     assert merged[0].scope == "user"
 
 
 def test_user_rule_overrides_global_with_different_label():
     g = [_base_rule(match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
-                    action={"label": "global", "category": "drink"})]
+                    action={"label": "global", "category": "Groceries"})]
     u = [Rule(scope="user", owner_user_id="1", priority=0, version=1, provenance="user", confidence=1.0,
              match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
-             action={"label": "user", "category": "drink"})]
+             action={"label": "user", "category": "Groceries"})]
     merged = merge_rules(g, u)
     assert len(merged) == 1
     assert merged[0].action.label == "user"
@@ -41,29 +41,29 @@ def test_precedence_priority_confidence_version_updated():
     now = datetime.utcnow()
     earlier = now - timedelta(days=1)
     rules = [
-        _base_rule(priority=2, confidence=0.8, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "misc"}),
-        _base_rule(priority=1, confidence=0.9, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "misc"})
+        _base_rule(priority=2, confidence=0.8, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "Utilities"}),
+        _base_rule(priority=1, confidence=0.9, match={"type": "contains", "pattern": "a", "fields": ["description"]}, action={"label": "a", "category": "Utilities"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].priority == 1
 
     rules = [
-        _base_rule(confidence=0.8, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "misc"}),
-        _base_rule(confidence=0.9, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "misc"})
+        _base_rule(confidence=0.8, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "Utilities"}),
+        _base_rule(confidence=0.9, match={"type": "contains", "pattern": "b", "fields": ["description"]}, action={"label": "b", "category": "Utilities"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].confidence == 0.9
 
     rules = [
-        _base_rule(version=1, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "misc"}),
-        _base_rule(version=2, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "misc"})
+        _base_rule(version=1, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "Utilities"}),
+        _base_rule(version=2, match={"type": "contains", "pattern": "c", "fields": ["description"]}, action={"label": "c", "category": "Utilities"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].version == 2
 
     rules = [
-        _base_rule(updated_at=earlier, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "misc"}),
-        _base_rule(updated_at=now, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "misc"})
+        _base_rule(updated_at=earlier, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "Utilities"}),
+        _base_rule(updated_at=now, match={"type": "contains", "pattern": "d", "fields": ["description"]}, action={"label": "d", "category": "Utilities"})
     ]
     merged = merge_rules(rules, [])
     assert merged[0].updated_at == now
@@ -72,16 +72,16 @@ def test_precedence_priority_confidence_version_updated():
 def test_match_strategies():
     exact_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
                       match={"type": "exact", "pattern": "Coffee Shop", "fields": ["description"]},
-                      action={"label": "exact", "category": "drink"})
+                      action={"label": "exact", "category": "Groceries"})
     contains_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
                          match={"type": "contains", "pattern": "coffee", "fields": ["description"]},
-                         action={"label": "contains", "category": "drink"})
+                         action={"label": "contains", "category": "Groceries"})
     regex_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
                       match={"type": "regex", "pattern": "^coffee", "flags": ["i"], "fields": ["description"]},
-                      action={"label": "regex", "category": "drink"})
+                      action={"label": "regex", "category": "Groceries"})
     signature_rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
                           match={"type": "signature", "pattern": "CoffeeShop", "fields": ["description"]},
-                          action={"label": "signature", "category": "drink"})
+                          action={"label": "signature", "category": "Groceries"})
 
     assert evaluate({"description": "Coffee Shop"}, [exact_rule]) == "exact"
     assert evaluate({"description": "my coffee"}, [contains_rule]) == "contains"
@@ -92,7 +92,7 @@ def test_match_strategies():
 def test_field_selection():
     rule = Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
                 match={"type": "contains", "pattern": "acme", "fields": ["counterparty"]},
-                action={"label": "vendor", "category": "biz"})
+                action={"label": "vendor", "category": "Fees"})
     data = {"description": "paycheck", "counterparty": "ACME Corp"}
     assert evaluate(data, [rule]) == "vendor"
 
@@ -101,10 +101,10 @@ def test_evaluate_uses_precedence():
     rules = [
         Rule(scope="global", priority=5, version=1, provenance="system", confidence=1.0,
              match={"type": "contains", "pattern": "shop", "fields": ["description"]},
-             action={"label": "low", "category": "misc"}),
+             action={"label": "low", "category": "Utilities"}),
         Rule(scope="global", priority=1, version=1, provenance="system", confidence=1.0,
              match={"type": "contains", "pattern": "shop", "fields": ["description"]},
-             action={"label": "high", "category": "misc"}),
+             action={"label": "high", "category": "Utilities"}),
     ]
     label = evaluate("coffee shop", merge_rules(rules, []))
     assert label == "high"

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,27 @@
+import pytest
+
+from backend.analytics import load_categories, validate_rule_categories
+from rules.engine import Action, Match, Rule, load_global_rules
+
+
+def test_categories_list_structure():
+    categories = load_categories()
+    assert isinstance(categories, list)
+    assert categories and all(isinstance(c, str) for c in categories)
+
+
+def test_global_rules_categories_in_taxonomy():
+    categories = set(load_categories())
+    rules = load_global_rules()
+    assert {r.action.category for r in rules} <= categories
+
+
+def test_validate_rule_categories_rejects_unknown():
+    rule = Rule(
+        scope="global",
+        priority=1,
+        match=Match(type="contains", pattern="foo", fields=["description"]),
+        action=Action(category="Nonexistent"),
+    )
+    with pytest.raises(ValueError):
+        validate_rule_categories([rule])


### PR DESCRIPTION
## Summary
- enforce sanctioned category taxonomy with loader and validator in rules engine
- expose taxonomy utilities in analytics and update heuristic rules
- document category taxonomy usage and add tests for category validation

## Testing
- `PYTHONPATH=. pytest tests/test_taxonomy.py tests/test_rules_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6895a6714de8832ba3dc5ef547d90e18