### PR TITLE
Track report generation costs and enforce LLM caps

### DIFF
--- a/backend/llm_adapter.py
+++ b/backend/llm_adapter.py
@@ -8,6 +8,7 @@ import os
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from contextlib import contextmanager
 from datetime import date
 from typing import Dict, Iterable, List, Tuple, Type
 
@@ -58,6 +59,18 @@ class DailyCostTracker:
             self.job_costs[job_id],
             self.daily_total,
         )
+
+    def add_raw_cost(self, job_id: int, cost: float) -> None:
+        """Record a non-token-based cost."""
+        self.add(job_id, 0, 0, cost)
+
+    @contextmanager
+    def track(self, job_id: int, cost: float, tokens_in: int = 0, tokens_out: int = 0):
+        """Context manager to record cost after a block completes."""
+        try:
+            yield
+        finally:
+            self.add(job_id, tokens_in, tokens_out, cost)
 
 
 _DAILY_LIMIT = float(os.getenv("MAX_DAILY_COST_GBP", "1.0"))

--- a/backend/report.py
+++ b/backend/report.py
@@ -85,7 +85,9 @@ def generate_report(job_id: int, llm: LLMFunc) -> Path:
 
     html_str = content if isinstance(content, str) else str(content)
     css = CSS(string=A4_CSS)
-    pdf_bytes = HTML(string=html_str).write_pdf(stylesheets=[css])
+    pdf_cost = float(os.getenv("WEASYPRINT_COST_GBP", "0.01"))
+    with cost_tracker.track(job_id, pdf_cost):
+        pdf_bytes = HTML(string=html_str).write_pdf(stylesheets=[css])
 
     if len(pdf_bytes) > 5 * 1024 * 1024:
         raise RuntimeError("Generated PDF too large")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -98,11 +98,15 @@ def test_report_generation(client: tuple[TestClient, any], tmp_path: Path):
     assert pdf_path.exists()
 
     with Session(engine) as session:
-        entry = session.exec(select(LLMCost)).one()
-        assert entry.job_id == job_id
-        assert entry.tokens_in == 10
-        assert entry.tokens_out == 5
-        assert entry.estimated_cost_gbp > 0
+        entries = list(session.exec(select(LLMCost)))
+        assert len(entries) == 2
+        llm_entry = next(e for e in entries if e.tokens_in == 10)
+        pdf_entry = next(e for e in entries if e.tokens_in == 0)
+        assert llm_entry.job_id == job_id
+        assert pdf_entry.job_id == job_id
+        assert llm_entry.tokens_out == 5
+        assert pdf_entry.tokens_out == 0
+        assert pdf_entry.estimated_cost_gbp > 0
 
 
 def test_report_missing_summary(client: tuple[TestClient, any]):


### PR DESCRIPTION
## Summary
- add helpers to `DailyCostTracker` for recording non-token costs
- track WeasyPrint PDF generation cost and combine with classification
- test cost tracking and limit enforcement for reports

## Testing
- `pytest tests/test_llm_adapter.py tests/test_report.py -q -W ignore::DeprecationWarning`


------
https://chatgpt.com/codex/tasks/task_e_6895a9af19f0832baa1962cb5ae39118