### PR TITLE
chore: reorder imports in rule engine

### DIFF
--- a/rules/engine.py
+++ b/rules/engine.py
@@ -1,7 +1,7 @@
-import re
-import json
-from datetime import datetime
 from pathlib import Path
+import json
+import re
+from datetime import datetime
 from typing import Iterable, List, Optional, Union
 from uuid import UUID, uuid4
 


### PR DESCRIPTION
## Summary
- group rule engine imports at top

## Testing
- `ruff check rules/engine.py`
- `PYTHONPATH=. pytest tests/test_rules_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895bbbb427c832bb1c50eca29044147