### PR TITLE
chore(signing): ensure crypto imports

### DIFF
--- a/backend/signing.py
+++ b/backend/signing.py
@@ -1,3 +1,5 @@
+"""Utilities for generating and verifying signed URLs."""
+
 import hashlib
 import hmac
 import os


### PR DESCRIPTION
## Summary
- document signing utilities module
- ensure os, hmac, and hashlib are imported at module scope

## Testing
- `poetry run ruff check backend/signing.py`
- `poetry run pytest tests/test_signing.py tests/test_backend_api.py::test_download tests/test_backend_api.py::test_download_expired -q`
- `poetry run behave features/backend_api.feature`


------
https://chatgpt.com/codex/tasks/task_e_6895bd0f8d0c832b9596be416bbd275a