### PR TITLE
test: document datetime imports in rules engine tests

### DIFF
--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta  # for date calculations
 
 from rules.engine import Rule, merge_rules, evaluate
 


### PR DESCRIPTION
## Summary
- document datetime and timedelta usage in rules engine tests

## Testing
- `python -m pytest tests/test_rules_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6895bebf401c832bb828b0337227e9df