### PR TITLE
Handle optional WeasyPrint dependency and mock in tests

### DIFF
--- a/backend/report.py
+++ b/backend/report.py
@@ -12,8 +12,6 @@ from .auth import auth_dependency
 from .signing import generate_signed_url
 from backend.llm_adapter import cost_tracker
 
-from weasyprint import HTML, CSS
-
 # LLM callable returning generated HTML and usage statistics
 LLMFunc = Callable[[str], Tuple[str, Dict[str, int]]]
 
@@ -61,6 +59,12 @@ def _report_path(job_id: int) -> Path:
 
 def generate_report(job_id: int, llm: LLMFunc) -> Path:
     """Generate a PDF report for the given job using the provided LLM."""
+    try:  # noqa: PLC0415 - imported inside for optional dependency
+        from weasyprint import HTML, CSS
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "WeasyPrint is required to generate PDF reports"
+        ) from exc
     summary_file = _summary_path(job_id)
     if not summary_file.exists():
         raise FileNotFoundError("Summary not found")

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -1,6 +1,8 @@
 import gzip
 import os
 import json
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,14 @@ from backend.app import app
 from backend.llm_adapter import get_adapter, AbstractAdapter
 from backend.database import get_session
 from backend.signing import generate_signed_url
+
+
+@pytest.fixture(autouse=True)
+def _mock_weasyprint(monkeypatch):
+    if "weasyprint" not in sys.modules:
+        monkeypatch.setitem(
+            sys.modules, "weasyprint", types.SimpleNamespace(HTML=None, CSS=None)
+        )
 
 
 @pytest.fixture(name="client")
@@ -69,7 +79,7 @@ def test_upload_gzip(client: TestClient):
 
 
 def test_rules(client: TestClient):
-    client.post("/rules", json={"label": "allow", "pattern": "allow"})
+    client.post("/rules", json={"label": "allow", "pattern": "allowed"})
     rules = client.get("/rules").json()
     assert any(r["label"] == "allow" for r in rules)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,7 @@
 import json
 import os
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -53,8 +55,8 @@ def client_fixture(tmp_path: Path, monkeypatch):
     tracker = DailyCostTracker(limit=1.0)
     monkeypatch.setattr("backend.llm_adapter.cost_tracker", tracker)
     monkeypatch.setattr("backend.llm_adapter.get_session", get_session_override)
-    monkeypatch.setattr(report, "HTML", DummyHTML)
-    monkeypatch.setattr(report, "CSS", DummyCSS)
+    dummy_weasy = types.SimpleNamespace(HTML=DummyHTML, CSS=DummyCSS)
+    monkeypatch.setitem(sys.modules, "weasyprint", dummy_weasy)
 
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_llm] = lambda: dummy_llm

--- a/tests/test_rule_validation.py
+++ b/tests/test_rule_validation.py
@@ -1,4 +1,7 @@
 import os
+import sys
+import types
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
@@ -6,6 +9,14 @@ from sqlalchemy.pool import StaticPool
 
 from backend.app import app
 from backend.database import get_session
+
+
+@pytest.fixture(autouse=True)
+def _mock_weasyprint(monkeypatch):
+    if "weasyprint" not in sys.modules:
+        monkeypatch.setitem(
+            sys.modules, "weasyprint", types.SimpleNamespace(HTML=None, CSS=None)
+        )
 
 
 @pytest.fixture(name="client")


### PR DESCRIPTION
## Summary
- Import WeasyPrint lazily inside `generate_report` and raise a clear error if missing
- Mock or skip WeasyPrint in backend API, rule validation, and report tests
- Use valid rule pattern in backend API tests

## Testing
- `PYTHONPATH=. pytest tests/test_report.py tests/test_backend_api.py tests/test_rule_validation.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689655f65964832bb49fc491e593a437