### PR TITLE
Remove duplicate import in LLM adapter tests

### DIFF
--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import pytest
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- remove redundant `pytest` import from `tests/test_llm_adapter.py`

## Testing
- `ruff check --fix tests/test_llm_adapter.py`
- `pytest tests/test_llm_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68966b77ce80832b85f32d2f1bf43e06