### PR TITLE
feat(frontend): add cn utility function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,7 @@ summary.csv
 # Node
 frontend/node_modules/
 frontend/dist/
+
+# Allow frontend lib utilities
+!frontend/src/lib/
+!frontend/src/lib/**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,12 +10,13 @@
     "test": "playwright test"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3",
-    "class-variance-authority": "^0.7.0",
-    "tailwind-merge": "^2.2.1",
-    "@radix-ui/react-slot": "^1.0.2"
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { twMerge } from "tailwind-merge";
+import clsx, { type ClassValue } from "clsx";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+


### PR DESCRIPTION
## Summary
- add cn helper using clsx and tailwind-merge
- add clsx dependency and allow lib directory

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68966cac0904832bb51238c2fe6c01e3