### PR TITLE
Install frontend dependencies during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 install:
 	poetry install --with dev
+	cd frontend && npm install
 
 unit:
 	poetry run pytest


### PR DESCRIPTION
## Summary
- install frontend packages in Makefile install target

## Testing
- `make lint` (fails: `backend.report imported but unused`)
- `make test` (fails: requires user input)


------
https://chatgpt.com/codex/tasks/task_e_68972c83ca5c832b8830f6243acf80b9