### PR TITLE
Add start target to run API and frontend via Docker Compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit behave component lint e2e
+.PHONY: install test unit behave component lint e2e start
 
 install:
 	poetry install --with dev
@@ -27,5 +27,8 @@ e2e:
 	elif docker compose version >/dev/null 2>&1; then \
 	docker compose up --build frontend e2e; \
 	else \
-	docker-compose up --build frontend e2e; \
-	fi
+        docker-compose up --build frontend e2e; \
+        fi
+
+start:
+	docker compose up --build api frontend


### PR DESCRIPTION
## Summary
- add `start` target to Makefile to build and run API and frontend services
- document new target in `.PHONY`

## Testing
- `make test` *(fails: ABORTED: By user)*
- `timeout 5 make e2e` *(fails: docker-compose: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897303e3044832b8376ab66f8544913