### PR TITLE
Add frontend tests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test unit behave component lint e2e start
+.PHONY: install test unit behave component lint e2e start frontend-test
 
 install:
 	poetry install --with dev
@@ -16,6 +16,7 @@ component:
 test:
 	poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
 	poetry run behave
+	cd frontend && npm test
 
 lint:
 	poetry run ruff check .
@@ -32,3 +33,6 @@ e2e:
 
 start:
 	docker compose up --build api frontend
+
+frontend-test:
+	cd frontend && npm test


### PR DESCRIPTION
## Summary
- run frontend tests from `make test`
- add standalone `make frontend-test` target

## Testing
- `make test` *(failed: ABORTED: By user)*
- `make frontend-test` *(failed: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68973262a364832b849a038d075ec68d