### PR TITLE
chore: remove unused report import

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -10,7 +10,6 @@ from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel, Session, create_engine, select
 
 from backend.app import app
-from backend import report
 from backend.report import get_llm
 from backend.database import get_session
 from backend.models import LLMCost


### PR DESCRIPTION
## Summary
- remove unused report import from tests

## Testing
- `make lint` *(fails: bankcleanr/pii.py:48 Incompatible types in assignment)*
- `make test` *(fails: interactive prompt during behave features)*

------
https://chatgpt.com/codex/tasks/task_e_6897398a71c8832bb2e20e5a942b0dce