### PR TITLE
Fix rule engine BDD tests and NDJSON uploads

### DIFF
--- a/features/rule_auto_learning.feature
+++ b/features/rule_auto_learning.feature
@@ -2,7 +2,7 @@ Feature: Rule auto-learning
   Scenario: LLM classification creates a persistent rule
     Given the API client
     And a fake adapter returning label "snacks" with confidence 0.9
-    When I upload text "Shop 123"
+    When I upload text "Corner Shop 123"
     And I classify with user id 1
     And I classify with user id 1
     Then the classification label is "snacks"

--- a/features/steps/backend_api_steps.py
+++ b/features/steps/backend_api_steps.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
+import json
 
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, Session, create_engine
@@ -34,8 +35,11 @@ def given_client(context):
 
 @when('I upload text "{text}"')
 def when_upload_text(context, text):
+    data = text
+    if not text.strip().startswith("{"):
+        data = json.dumps({"description": text})
     resp = context.client.post(
-        "/upload", data=text, headers={"Content-Type": "text/plain"}
+        "/upload", data=data, headers={"Content-Type": "application/x-ndjson"}
     )
     context.job_id = resp.json()["job_id"]
 

--- a/features/steps/rule_engine_steps.py
+++ b/features/steps/rule_engine_steps.py
@@ -35,7 +35,7 @@ def when_classify(context, user_id):
 
 @then('the classification label is "{label}"')
 def then_classification_label(context, label):
-    assert context.classification["label"] == label
+    assert context.classification["results"][0]["label"] == label
     if not getattr(context, "preserve_client", False):
         context.client.close()
         app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- Send NDJSON with description field when uploading text in Behave steps
- Read classification label from results list and import os in rule engine steps
- Use longer example in auto-learning feature to satisfy rule creation requirements

## Testing
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_689742d5e834832b966e7dc59e141044