### PR TITLE
Ensure Playwright tests install dependencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "playwright test"
+    "test": "npm install && npx playwright install --with-deps chromium && npx playwright test"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",


### PR DESCRIPTION
## Summary
- Install Node dependencies and Playwright browsers automatically before running frontend tests

## Testing
- `poetry run pytest`
- `poetry run behave`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976dcf446c832b894de9802e9d7ae1