### PR TITLE
chore: install frontend deps before tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ component:
 test:
 	poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
 	poetry run behave
-	cd frontend && npm test
+	cd frontend && npm ci && npm test
 
 lint:
 	poetry run ruff check .
@@ -28,11 +28,11 @@ e2e:
 	elif docker compose version >/dev/null 2>&1; then \
 	docker compose up --build frontend e2e; \
 	else \
-        docker-compose up --build frontend e2e; \
-        fi
+	docker-compose up --build frontend e2e; \
+	fi
 
 start:
 	docker compose up --build api frontend
 
 frontend-test:
-	cd frontend && npm test
+	cd frontend && npm ci && npm test


### PR DESCRIPTION
## Summary
- ensure `make test` installs frontend dev dependencies before running Cypress
- do the same for `make frontend-test`

## Testing
- `make frontend-test` *(fails: /root/.cache/Cypress/13.7.3/Cypress/Cypress: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689789111578832b8f7d95b41027421c