### PR TITLE
Update job status after classification

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -184,100 +184,114 @@ def classify(
     upload = session.get(Upload, job.upload_id)
     if upload is None:
         raise HTTPException(status_code=404, detail="Upload not found")
-    # Parse NDJSON content into transaction records
-    transactions = []
-    for line in upload.content.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            tx = json.loads(line)
-        except json.JSONDecodeError as e:
-            raise HTTPException(status_code=400, detail=f"Invalid JSON line: {e}")
-        description = tx.get("description", "")
-        signature = normalise_signature(description)
-        tx_record = {**tx, "merchant_signature": signature}
-        transactions.append(tx_record)
+    # Update status so async clients know work has started
+    job.status = "processing"
+    session.add(job)
+    session.commit()
+    try:
+        # Parse NDJSON content into transaction records
+        transactions = []
+        for line in upload.content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                tx = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise HTTPException(status_code=400, detail=f"Invalid JSON line: {e}")
+            description = tx.get("description", "")
+            signature = normalise_signature(description)
+            tx_record = {**tx, "merchant_signature": signature}
+            transactions.append(tx_record)
 
-    user_rules_all = session.exec(
-        select(UserRule).where(UserRule.user_id == req.user_id)
-    ).all()
-    latest: dict[str, UserRule] = {}
-    for r in user_rules_all:
-        if r.pattern not in latest or r.version > latest[r.pattern].version:
-            latest[r.pattern] = r
-    engine_rules = [_convert_user_rule(r) for r in latest.values()]
-    rules = merge_rules(GLOBAL_RULES, engine_rules)
+        user_rules_all = session.exec(
+            select(UserRule).where(UserRule.user_id == req.user_id)
+        ).all()
+        latest: dict[str, UserRule] = {}
+        for r in user_rules_all:
+            if r.pattern not in latest or r.version > latest[r.pattern].version:
+                latest[r.pattern] = r
+        engine_rules = [_convert_user_rule(r) for r in latest.values()]
+        rules = merge_rules(GLOBAL_RULES, engine_rules)
 
-    results: list[dict] = []
-    unknown_signatures = []
-    for tx in transactions:
-        label = evaluate(tx, rules)
-        tx["_label"] = label
-        if not label:
+        results: list[dict] = []
+        unknown_signatures = []
+        for tx in transactions:
+            label = evaluate(tx, rules)
+            tx["_label"] = label
+            if not label:
+                sig = tx["merchant_signature"]
+                if sig not in SIGNATURE_CACHE and sig not in unknown_signatures:
+                    unknown_signatures.append(sig)
+
+        if unknown_signatures:
+            responses = adapter.classify(unknown_signatures, job_id=req.job_id)
+            for sig, resp in zip(unknown_signatures, responses):
+                SIGNATURE_CACHE[sig] = resp
+
+        processed_signatures: set[str] = set()
+        for tx in transactions:
+            label = tx.get("_label")
             sig = tx["merchant_signature"]
-            if sig not in SIGNATURE_CACHE and sig not in unknown_signatures:
-                unknown_signatures.append(sig)
-
-    if unknown_signatures:
-        responses = adapter.classify(unknown_signatures, job_id=req.job_id)
-        for sig, resp in zip(unknown_signatures, responses):
-            SIGNATURE_CACHE[sig] = resp
-
-    processed_signatures: set[str] = set()
-    for tx in transactions:
-        label = tx.get("_label")
-        sig = tx["merchant_signature"]
-        if not label:
-            response = SIGNATURE_CACHE[sig]
-            label = response["label"]
-            confidence = response.get("confidence", 0.0)
-            if sig not in processed_signatures and confidence >= 0.85:
-                if sum(c.isalpha() for c in norm(sig)) < 6:
-                    processed_signatures.add(sig)
-                    continue
-                existing = session.exec(
-                    select(UserRule)
-                    .where(UserRule.user_id == req.user_id)
-                    .where(UserRule.pattern == sig)
-                    .order_by(UserRule.version.desc())  # type: ignore[attr-defined]
-                ).first()
-                if existing:
-                    if existing.field != "merchant_signature" or confidence < 0.95:
+            if not label:
+                response = SIGNATURE_CACHE[sig]
+                label = response["label"]
+                confidence = response.get("confidence", 0.0)
+                if sig not in processed_signatures and confidence >= 0.85:
+                    if sum(c.isalpha() for c in norm(sig)) < 6:
                         processed_signatures.add(sig)
                         continue
-                    session.add(
-                        UserRule(
-                            user_id=req.user_id,
-                            label=label,
-                            pattern=sig,
-                            match_type="exact",
-                            field="merchant_signature",
-                            priority=existing.priority,
-                            confidence=confidence,
-                            version=existing.version + 1,
+                    existing = session.exec(
+                        select(UserRule)
+                        .where(UserRule.user_id == req.user_id)
+                        .where(UserRule.pattern == sig)
+                        .order_by(UserRule.version.desc())  # type: ignore[attr-defined]
+                    ).first()
+                    if existing:
+                        if existing.field != "merchant_signature" or confidence < 0.95:
+                            processed_signatures.add(sig)
+                            continue
+                        session.add(
+                            UserRule(
+                                user_id=req.user_id,
+                                label=label,
+                                pattern=sig,
+                                match_type="exact",
+                                field="merchant_signature",
+                                priority=existing.priority,
+                                confidence=confidence,
+                                version=existing.version + 1,
+                            )
                         )
-                    )
-                    session.commit()
-                else:
-                    session.add(
-                        UserRule(
-                            user_id=req.user_id,
-                            label=label,
-                            pattern=sig,
-                            match_type="exact",
-                            field="merchant_signature",
-                            priority=0,
-                            confidence=confidence,
-                            version=1,
+                        session.commit()
+                    else:
+                        session.add(
+                            UserRule(
+                                user_id=req.user_id,
+                                label=label,
+                                pattern=sig,
+                                match_type="exact",
+                                field="merchant_signature",
+                                priority=0,
+                                confidence=confidence,
+                                version=1,
+                            )
                         )
-                    )
-                    session.commit()
-            processed_signatures.add(sig)
-        result = ClassificationResult(job_id=req.job_id, result=label, status="completed")
-        session.add(result)
-        session.commit()
-        session.refresh(result)
-        results.append({"classification_id": result.id, "label": label})
+                        session.commit()
+                processed_signatures.add(sig)
+            result = ClassificationResult(job_id=req.job_id, result=label, status="completed")
+            session.add(result)
+            session.commit()
+            session.refresh(result)
+            results.append({"classification_id": result.id, "label": label})
 
-    return {"results": results}
+        # Mark completion
+        job.status = "completed"
+        session.add(job)
+        session.commit()
+        return {"results": results}
+    except Exception:
+        job.status = "failed"
+        session.add(job)
+        session.commit()
+        raise

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -99,6 +99,9 @@ def test_classify(client: TestClient):
     resp = client.post("/classify", json={"job_id": job_id})
     labels = [r["label"] for r in resp.json()["results"]]
     assert labels == ["unknown", "unknown"]
+    # ensure the job status is updated once processing is complete
+    status = client.get(f"/status/{job_id}").json()["status"]
+    assert status == "completed"
 
 
 def test_classify_applies_user_rule(client: TestClient):


### PR DESCRIPTION
## Summary
- Mark processing jobs as `processing` while they run and `completed` when finished
- Record `failed` status if classification errors
- Extend backend API tests to ensure job status transitions to `completed`

## Testing
- `PYTHONPATH=. pytest tests/test_backend_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898618ec16c832b8c826e4668485d58