### PR TITLE
docs: document bank parser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ npm run build # create production assets
 Create self-contained binaries for the extractor:
 
 ```bash
-poetry run bankcleanr build
-```
+   poetry run bankcleanr build
+   ```
 
 ## Setup with Poetry
 
@@ -61,6 +61,24 @@ poetry run bankcleanr build
    ```
 
    Alternatively, run `make install` if you prefer using the new Makefile.
+
+## Supported banks
+
+The extractor ships with parsers for a few UK banks:
+
+- `barclays`
+- `hsbc`
+- `lloyds`
+
+Select the appropriate parser with the `--bank` option:
+
+```bash
+poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc
+```
+
+Unit tests for these parsers live in [`tests/test_parsers.py`](tests/test_parsers.py).
+Contributors adding a new bank should extend that file with corresponding
+coverage.
 
 ## Running the tests
 

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -22,7 +22,11 @@ app = typer.Typer()
 def extract(
     input_pdf: Path,
     output_jsonl: Path,
-    bank: str = typer.Option("barclays", "--bank", help="Bank identifier"),
+    bank: str = typer.Option(
+        "barclays",
+        "--bank",
+        help="Bank identifier (barclays, hsbc, lloyds)",
+    ),
     mask_names: str = typer.Option("", "--mask-names", help="Comma-separated names to mask"),
 ) -> None:
     """Extract transactions from PDF and write JSONL."""


### PR DESCRIPTION
## Summary
- list available bank parsers in CLI option help
- document supported banks and parser tests in README

## Testing
- `PYTHONPATH=. pytest tests/test_parsers.py`
- `behave features/extract_barclays.feature features/extract_hsbc.feature features/extract_lloyds.feature features/placeholder.feature </dev/null`

------
https://chatgpt.com/codex/tasks/task_e_689872aa36ec832b8de5f25c11cfa32e