### PR TITLE
Support directory PDF extraction

### DIFF
--- a/features/extract_directory.feature
+++ b/features/extract_directory.feature
@@ -1,0 +1,5 @@
+Feature: Directory PDF extraction
+  Scenario: CLI extracts transactions from a directory
+    Given multiple barclays statements
+    When I run the barclays extractor on the directory
+    Then a JSONL file with 4 transactions is created

--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -63,6 +63,7 @@ def step_run_extractor(context, bank):
         ],
         check=True,
         env={**os.environ, "PYTHONPATH": os.getcwd()},
+        stdin=subprocess.DEVNULL,
     )
 
 
@@ -72,3 +73,31 @@ def step_then_check(context, count):
         lines = fh.readlines()
     assert len(lines) == count
     context.tmpdir.cleanup()
+
+
+@given("multiple {bank} statements")
+def step_given_multiple(context, bank):
+    context.tmpdir = tempfile.TemporaryDirectory()
+    context.pdf_dir = context.tmpdir.name
+    for name in ["a.pdf", "b.pdf"]:
+        _create_pdf(os.path.join(context.pdf_dir, name), bank)
+
+
+@when("I run the {bank} extractor on the directory")
+def step_run_extractor_dir(context, bank):
+    context.jsonl_path = os.path.join(context.tmpdir.name, "out.jsonl")
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "bankcleanr.cli",
+            "extract",
+            "--bank",
+            bank,
+            context.pdf_dir,
+            context.jsonl_path,
+        ],
+        check=True,
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        stdin=subprocess.DEVNULL,
+    )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -59,10 +59,20 @@ def test_extract_transactions(bank, expected):
     with tempfile.TemporaryDirectory() as tmp:
         pdf_path = os.path.join(tmp, f"{bank}.pdf")
         _create_pdf(pdf_path, bank)
-        records = extract_transactions(pdf_path, bank=bank)
+        records = list(extract_transactions(pdf_path, bank=bank))
         assert len(records) == expected
         for rec in records:
             jsonschema.validate(rec, SCHEMA)
             assert re.match(r"^\d{4}-\d{2}-\d{2}$", rec["date"])
             assert re.match(r"^[+-]\d+\.\d{2}$", rec["amount"])
         assert any(r["amount"].startswith("+") for r in records)
+
+
+def test_extract_transactions_directory():
+    with tempfile.TemporaryDirectory() as tmp:
+        pdf1 = os.path.join(tmp, "a.pdf")
+        pdf2 = os.path.join(tmp, "b.pdf")
+        _create_pdf(pdf1, "barclays")
+        _create_pdf(pdf2, "barclays")
+        records = list(extract_transactions(tmp, bank="barclays"))
+        assert len(records) == 4


### PR DESCRIPTION
## Summary
- enable `extract_transactions` to iterate over PDFs in a directory
- allow CLI `extract` command to accept directories and stream output
- verify directory handling with new unit and BDD tests

## Testing
- `python -m pytest tests/test_parsers.py tests/test_extractor.py tests/test_cli_schema_validation.py`
- `behave features/extract_directory.feature`


------
https://chatgpt.com/codex/tasks/task_e_68988225e0f8832b9b94bea3e4117993