### PR TITLE
Add Co-op bank parser and tests

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -28,7 +28,7 @@ def extract(
     bank: str = typer.Option(
         "barclays",
         "--bank",
-        help="Bank identifier (barclays, hsbc, lloyds)",
+        help="Bank identifier (barclays, hsbc, lloyds, coop)",
     ),
     mask_names: str = typer.Option("", "--mask-names", help="Comma-separated names to mask"),
 ) -> None:

--- a/bankcleanr/parsers/coop.py
+++ b/bankcleanr/parsers/coop.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+from datetime import datetime
+from decimal import Decimal
+
+import pdfplumber
+
+from ..pii import mask_pii
+from ..signature import normalise_signature
+
+# Co-op statements have separate Moneyout and Moneyin columns
+# followed by the running Balance. Amounts are always positive
+# and the sign is determined by which column they appear in.
+_LINE_RE = re.compile(
+    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(\d+\.\d{2})\s+(\d+\.\d{2})\s+(\d+\.\d{2})$"
+)
+
+
+class CoopParser:
+    """Parse Co-op PDF statements into transactions."""
+
+    def parse(self, pdf_path: str) -> List[Dict[str, str | None]]:
+        records: List[Dict[str, str | None]] = []
+        with pdfplumber.open(pdf_path) as pdf:
+            for page in pdf.pages:
+                lines = page.extract_text().split("\n")
+                for line in lines:
+                    match = _LINE_RE.match(line.strip())
+                    if not match:
+                        continue
+                    date, desc, money_out, money_in, balance = match.groups()
+                    money_out_d = Decimal(money_out)
+                    money_in_d = Decimal(money_in)
+                    amount = money_in_d - money_out_d
+                    clean_desc = mask_pii(desc.strip())
+                    records.append(
+                        {
+                            "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
+                            "description": clean_desc,
+                            "amount": f"{amount:+.2f}",
+                            "balance": f"{Decimal(balance):+.2f}",
+                            "merchant_signature": normalise_signature(clean_desc),
+                        }
+                    )
+        return records
+
+
+BANK = "coop"
+Parser = CoopParser
+
+__all__ = ["CoopParser", "Parser", "BANK"]

--- a/features/extract_coop.feature
+++ b/features/extract_coop.feature
@@ -1,0 +1,5 @@
+Feature: Co-op PDF extraction
+  Scenario: CLI extracts transactions to JSONL
+    Given a sample coop statement
+    When I run the coop extractor
+    Then a JSONL file with 2 transactions is created

--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -29,6 +29,13 @@ def _create_pdf(path: str, bank: str) -> None:
             "01 Jan 2024 Rent -500.00 500.00",
             "02 Jan 2024 Salary 2000.00 2500.00",
         ]
+    elif bank == "coop":
+        lines = [
+            "Co-op Bank",
+            "Date Description Moneyout Moneyin Balance",
+            "01 Jan 2024 Coffee Shop 3.50 0.00 996.50",
+            "02 Jan 2024 Salary 0.00 2000.00 2996.50",
+        ]
     else:
         lines = ["Placeholder Bank"]
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -35,6 +35,13 @@ def _create_pdf(path: str, bank: str) -> None:
             "01 Jan 2024 Rent -500.00 500.00",
             "02 Jan 2024 Salary 2000.00 2500.00",
         ]
+    elif bank == "coop":
+        lines = [
+            "Co-op Bank",
+            "Date Description Moneyout Moneyin Balance",
+            "01 Jan 2024 Coffee Shop 3.50 0.00 996.50",
+            "02 Jan 2024 Salary 0.00 2000.00 2996.50",
+        ]
     else:
         lines = ["Placeholder Bank"]
 
@@ -52,6 +59,7 @@ def _create_pdf(path: str, bank: str) -> None:
         ("barclays", 2),
         ("hsbc", 2),
         ("lloyds", 2),
+        ("coop", 2),
         ("placeholder", 1),
     ],
 )


### PR DESCRIPTION
## Summary
- add Co-op bank PDF parser that normalises Moneyout/Moneyin columns
- include "coop" in CLI bank option and auto-register parser
- expand unit and BDD tests with synthetic Co-op statements

## Testing
- `PYTHONPATH=. pytest tests/test_parsers.py -q`
- `PYTHONPATH=. behave features/extract_coop.feature`


------
https://chatgpt.com/codex/tasks/task_e_6898908de468832bbe02e60e38e5cfa7