### PR TITLE
docs: add coop to supported banks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ poetry run bankcleanr build
 The extractor ships with parsers for a few UK banks:
 
 - `barclays`
+- `coop` (separate `Moneyout` and `Moneyin` columns)
 - `hsbc`
 - `lloyds`
 


### PR DESCRIPTION
## Summary
- document Co-op bank support with note about separate Moneyout and Moneyin columns

## Testing
- `pytest` *(fails: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_68989a57751c832ba615edc79f50d2e0