### PR TITLE
Copy rules directory into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install poetry \
 
 COPY backend ./backend
 COPY bankcleanr ./bankcleanr
+COPY rules ./rules
 
 # Document which port the FastAPI app listens on
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- include the `rules` package in the Docker image build

## Testing
- `pytest` *(fails: No module named 'jsonschema', 'fastapi', 'bankcleanr', etc.)*
- `docker build -t dogshit-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `podman build -t dogshit-test .` *(fails: error mounting "proc" to rootfs: operation not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_6898e7983524832b9d1649ba753be20b