### PR TITLE
Add parse alias for extractor CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ Run the extractor directly from source or build a self-contained binary:
 
 ```bash
 poetry run bankcleanr extract statement.pdf tx.jsonl
+poetry run bankcleanr parse statement.pdf tx.jsonl  # alias for extract
 poetry run bankcleanr build
 ```
+
+The `extract` command is also available as `parse` for backwards
+compatibility with existing workflows.
 
 ## Setup with Poetry
 
@@ -76,6 +80,7 @@ Select the appropriate parser with the `--bank` option:
 
 ```bash
 poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc
+poetry run bankcleanr parse statement.pdf tx.jsonl --bank hsbc
 ```
 
 Unit tests for these parsers live in [`tests/test_parsers.py`](tests/test_parsers.py).

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -44,6 +44,10 @@ def extract(
             fh.write(json.dumps(item) + "\n")
 
 
+# register an alias so older workflows using "parse" still function
+app.command(name="parse")(extract)
+
+
 @app.command()
 def build() -> None:
     """Build standalone executable using PyInstaller."""

--- a/features/parse_alias.feature
+++ b/features/parse_alias.feature
@@ -1,0 +1,5 @@
+Feature: Parse alias
+  Scenario: CLI parse command extracts transactions to JSONL
+    Given a sample coop statement
+    When I parse the coop statement
+    Then a JSONL file with 9 transactions is created

--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -45,6 +45,26 @@ def step_run_extractor(context, bank):
     )
 
 
+@when("I parse the {bank} statement")
+def step_parse_statement(context, bank):
+    context.jsonl_path = os.path.join(context.tmpdir.name, "out.jsonl")
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "bankcleanr.cli",
+            "parse",
+            "--bank",
+            bank,
+            context.pdf_path,
+            context.jsonl_path,
+        ],
+        check=True,
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        stdin=subprocess.DEVNULL,
+    )
+
+
 @then("a JSONL file with {count:d} transactions is created")
 def step_then_check(context, count):
     with open(context.jsonl_path, "r", encoding="utf-8") as fh:

--- a/tests/test_cli_schema_validation.py
+++ b/tests/test_cli_schema_validation.py
@@ -18,3 +18,29 @@ def test_cli_validates_records(tmp_path, monkeypatch):
     result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
     assert result.exit_code != 0
     assert isinstance(result.exception, ValidationError)
+
+
+def test_cli_parse_alias(tmp_path, monkeypatch):
+    runner = CliRunner()
+
+    def fake_extract(pdf_path: str, bank: str = "barclays"):
+        return [
+            {
+                "date": "01 Jan 2024",
+                "description": "x",
+                "amount": "1",
+                "merchant_signature": "",
+            }
+        ]
+
+    monkeypatch.setattr(cli, "extract_transactions", fake_extract)
+
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    out = tmp_path / "out.jsonl"
+    result = runner.invoke(cli.app, ["parse", str(pdf), str(out)])
+    assert result.exit_code == 0
+    assert (
+        out.read_text()
+        == '{"date": "01 Jan 2024", "description": "x", "amount": "1", "merchant_signature": ""}\n'
+    )


### PR DESCRIPTION
## Summary
- expose `extract` command under a new `parse` alias for backwards compatibility
- document the `parse` alias in the README
- test CLI alias via unit and BDD tests

## Testing
- `poetry run pytest tests/test_cli_schema_validation.py::test_cli_parse_alias -q`
- `poetry run behave features/parse_alias.feature` *(fails: FileNotFoundError: tests/fixtures/coop/statement_1.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_68999e9af60c832ba4e70aa0919addec