### PR TITLE
Fix CLI imports for standalone use

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import jsonschema
 import typer
 
-from .extractor import extract_transactions
-from .pii import mask_pii
+from bankcleanr.extractor import extract_transactions
+from bankcleanr.pii import mask_pii
 
 SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "transaction_v1.json"
 SCHEMA = json.loads(SCHEMA_PATH.read_text())

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -1,0 +1,12 @@
+from importlib import util
+from pathlib import Path
+
+
+def test_cli_importable_in_isolation():
+    """CLI module should import without package context."""
+    cli_path = Path(__file__).resolve().parents[1] / "bankcleanr" / "cli.py"
+    spec = util.spec_from_file_location("cli", cli_path)
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    assert hasattr(module, "app")


### PR DESCRIPTION
## Summary
- use absolute imports in CLI to avoid package context issues
- add test ensuring `bankcleanr.cli` imports in isolation

## Testing
- `PYTHONPATH=. pytest tests/test_cli_import.py tests/test_cli_schema_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_6899ac7dbcd8832b8fcadaba27de199d