### PR TITLE
Add platform-specific PyInstaller build and integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ component:
 	poetry run pytest tests/test_backend_api.py
 
 test:
-	poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
-	poetry run behave
-	cd frontend && npm ci && npm test
+        poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
+        poetry run behave
+        cd frontend && npm ci && npm test
 
 lint:
 	poetry run ruff check .
@@ -35,4 +35,7 @@ start:
 	docker compose up --build api frontend
 
 frontend-test:
-	cd frontend && npm ci && npm test
+        cd frontend && npm ci && npm test
+
+build-linux:
+	./scripts/build_linux.sh

--- a/README.md
+++ b/README.md
@@ -223,11 +223,19 @@ rule to the database.
 ## Building standalone executables
 
 Pre-built binaries for common platforms are available on the project's [GitHub releases](https://github.com/OWNER/REPO/releases) page.
-Run `bankcleanr build` to create a single-file binary for the current operating system:
+Run `bankcleanr build` to create a single-file binary for the current operating system. The output embeds the platform and architecture in its name, e.g. `bankcleanr-linux-x86_64`:
 
 ```bash
 poetry run bankcleanr build
 ```
+
+For Linux builds you can also run the helper script which performs the build inside Docker:
+
+```bash
+./scripts/build_linux.sh
+```
+
+macOS and Windows binaries must be built on their respective operating systems.
 
 Install `pyinstaller` first (either via `pip install pyinstaller` or
 `poetry install --with dev`). Because PyInstaller cannot cross compile you must
@@ -254,7 +262,7 @@ build. Installing Python from
 To verify a build you can run the binary on the included sample PDF:
 
 ```bash
-./dist/bankcleanr extract "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" tx.jsonl
+./dist/bankcleanr-linux-x86_64 extract "Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf" tx.jsonl --bank coop
 ```
 This command produces a `tx.jsonl` file containing the extracted transactions.
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker run --rm -v "$PWD":/app -w /app python:3.12-slim bash -c "pip install . jsonschema pyinstaller && python -m bankcleanr.cli build"

--- a/tests/test_pyinstaller_extract.py
+++ b/tests/test_pyinstaller_extract.py
@@ -1,18 +1,18 @@
-import subprocess
-import sys
+import json
 import platform
+import subprocess
 from pathlib import Path
 
 
-def test_schema_bundled_with_pyinstaller(tmp_path):
+def test_pyinstaller_extract(tmp_path):
     dist_dir = tmp_path / "dist"
     build_dir = tmp_path / "build"
     spec_dir = tmp_path / "spec"
     system = platform.system().lower()
     system_label = "macos" if system == "darwin" else system
     machine = platform.machine().lower()
-    name = f"bankcleanr-{system_label}-{machine}"
     sep = ";" if system.startswith("win") else ":"
+    name = f"bankcleanr-{system_label}-{machine}"
     schema = Path("bankcleanr/schemas/transaction_v1.json").resolve()
     subprocess.run(
         [
@@ -36,9 +36,13 @@ def test_schema_bundled_with_pyinstaller(tmp_path):
         ],
         check=True,
     )
-    executable = dist_dir / (name + (".exe" if system.startswith("win") else ""))
-    assert executable.exists()
+    exe = dist_dir / (name + (".exe" if system.startswith("win") else ""))
     sample_pdf = Path("Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf")
     out_jsonl = tmp_path / "out.jsonl"
-    subprocess.run([str(executable), "extract", str(sample_pdf), str(out_jsonl), "--bank", "coop"], check=True)
-    assert out_jsonl.read_text()
+    subprocess.run([str(exe), "extract", str(sample_pdf), str(out_jsonl), "--bank", "coop"], check=True)
+    assert out_jsonl.exists()
+    lines = out_jsonl.read_text().strip().splitlines()
+    assert lines
+    first = json.loads(lines[0])
+    assert {"date", "description", "amount", "balance"} <= first.keys()
+


### PR DESCRIPTION
## Summary
- Embed OS and architecture in `bankcleanr build` outputs and bundle schema via PyInstaller
- Add Docker-based Linux build helper and document platform-specific builds
- Test PyInstaller binary extracting transactions from sample PDF

## Testing
- `pytest tests/test_pyinstaller_schema.py`
- `pytest tests/test_pyinstaller_extract.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d578a37c832b95a7d944c6596c8a