### PR TITLE
Add cross-platform build workflow and Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,22 +10,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            artifact: bankcleanr-macos-intel
-            macos_arch: x86_64
+          - os: ubuntu-latest
+            artifact: bankcleanr-linux
             ext: ""
           - os: macos-latest
-            artifact: bankcleanr-macos-arm
-            macos_arch: arm64
+            artifact: bankcleanr-macos
             ext: ""
           - os: windows-latest
             artifact: bankcleanr-windows
-            macos_arch: ""
             ext: ".exe"
-          - os: ubuntu-latest
-            artifact: bankcleanr-linux
-            macos_arch: ""
-            ext: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,11 +30,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install poetry
-          poetry install --only main
+          poetry install
       - name: Build executable
-        run: poetry run bankcleanr.cli build
-        env:
-          MACOS_ARCH: ${{ matrix.macos_arch }}
+        run: poetry run bankcleanr build
       - name: Prepare artifact (Unix)
         if: matrix.os != 'windows-latest'
         run: |

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+WORKDIR /app
+
+# Disable virtual environments so dependencies install directly into the container image.
+ENV POETRY_VIRTUALENVS_CREATE=false
+
+# Install dependencies first to leverage Docker layer caching.
+COPY pyproject.toml poetry.lock README.md ./
+RUN pip install poetry \
+    && poetry install --with dev
+
+# Copy the project source.
+COPY . .
+
+# Default command builds the CLI binary. Override the command to run tests or other tasks.
+CMD ["poetry", "run", "bankcleanr", "build"]


### PR DESCRIPTION
## Summary
- build releases on Linux, macOS, and Windows with Poetry
- add Dockerfile.build for containerized CLI builds

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e65df3fc832b9ec53022ecb2def0