### PR TITLE
Fix lint target and clean schema handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ component:
 	poetry run pytest tests/test_backend_api.py
 
 test:
-        poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
-        poetry run behave
-        cd frontend && npm ci && npm test
+	poetry run pytest --cov=. --cov-fail-under=$${COV_FAIL_UNDER:-50}
+	poetry run behave
+	cd frontend && npm ci && npm test
 
 lint:
 	poetry run ruff check .
@@ -35,7 +35,7 @@ start:
 	docker compose up --build api frontend
 
 frontend-test:
-        cd frontend && npm ci && npm test
+	cd frontend && npm ci && npm test
 
 build-linux:
 	./scripts/build_linux.sh

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import platform
 from importlib import resources
+from importlib.abc import Traversable
 from pathlib import Path
 
 import jsonschema
@@ -14,6 +15,7 @@ import typer
 from bankcleanr.extractor import extract_transactions
 from bankcleanr.pii import mask_pii
 
+SCHEMA_PATH: Path | Traversable
 if getattr(sys, "frozen", False):
     SCHEMA_PATH = Path(sys._MEIPASS) / "schemas" / "transaction_v1.json"  # type: ignore[attr-defined]
 else:

--- a/tests/test_pyinstaller_schema.py
+++ b/tests/test_pyinstaller_schema.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 import platform
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- fix Makefile tabs so `make lint` runs
- tidy CLI schema path typing for mypy
- drop unused imports in PyInstaller test

## Testing
- `poetry run pytest`
- `poetry run behave`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6899a9a42a78832b897bb59d83ae55eb