### PR TITLE
fix: allow build from any directory

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -64,6 +64,9 @@ def build() -> None:
     machine = platform.machine().lower()
     name = f"bankcleanr-{system}-{machine}"
     sep = ";" if system.startswith("win") else ":"
+    root = Path(__file__).resolve().parent
+    schema = root / "schemas" / "transaction_v1.json"
+    cli_path = Path(__file__).resolve()
     subprocess.run(
         [
             "pyinstaller",
@@ -71,12 +74,12 @@ def build() -> None:
             name,
             "--onefile",
             "--add-data",
-            f"bankcleanr/schemas/transaction_v1.json{sep}schemas",
+            f"{schema}{sep}schemas",
             "--collect-submodules",
             "bankcleanr.parsers",
             "--hidden-import",
             "bankcleanr.schemas",
-            "bankcleanr/cli.py",
+            str(cli_path),
         ],
         check=True,
     )

--- a/features/build.feature
+++ b/features/build.feature
@@ -1,0 +1,5 @@
+Feature: Build bankcleanr executable
+  Scenario: Building from arbitrary directory
+    Given a temporary working directory for build
+    When I run the bankcleanr build command
+    Then a bankcleanr executable is created

--- a/features/steps/build_steps.py
+++ b/features/steps/build_steps.py
@@ -1,0 +1,37 @@
+import os
+import platform
+import subprocess
+import tempfile
+from pathlib import Path
+
+from behave import given, when, then  # type: ignore[import-untyped]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@given("a temporary working directory for build")
+def step_tmpdir(context):
+    context.tmpdir = tempfile.TemporaryDirectory()
+    context.cwd = Path(context.tmpdir.name)
+
+
+@when("I run the bankcleanr build command")
+def step_run_build(context):
+    subprocess.run(
+        ["python", "-m", "bankcleanr.cli", "build"],
+        cwd=context.cwd,
+        check=True,
+        env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+        stdin=subprocess.DEVNULL,
+    )
+
+
+@then("a bankcleanr executable is created")
+def step_executable_created(context):
+    system = platform.system().lower()
+    system_label = "macos" if system == "darwin" else system
+    machine = platform.machine().lower()
+    name = f"bankcleanr-{system_label}-{machine}"
+    exe = context.cwd / "dist" / (name + (".exe" if system.startswith("win") else ""))
+    assert exe.exists()
+    context.tmpdir.cleanup()

--- a/tests/test_pyinstaller_extract.py
+++ b/tests/test_pyinstaller_extract.py
@@ -1,42 +1,23 @@
 import json
+import os
 import platform
 import subprocess
 from pathlib import Path
 
 
 def test_pyinstaller_extract(tmp_path):
-    dist_dir = tmp_path / "dist"
-    build_dir = tmp_path / "build"
-    spec_dir = tmp_path / "spec"
     system = platform.system().lower()
     system_label = "macos" if system == "darwin" else system
     machine = platform.machine().lower()
-    sep = ";" if system.startswith("win") else ":"
     name = f"bankcleanr-{system_label}-{machine}"
-    schema = Path("bankcleanr/schemas/transaction_v1.json").resolve()
     subprocess.run(
-        [
-            "pyinstaller",
-            "--name",
-            name,
-            "--onefile",
-            "--add-data",
-            f"{schema}{sep}schemas",
-            "--collect-submodules",
-            "bankcleanr.parsers",
-            "--hidden-import",
-            "bankcleanr.schemas",
-            "--distpath",
-            str(dist_dir),
-            "--workpath",
-            str(build_dir),
-            "--specpath",
-            str(spec_dir),
-            "bankcleanr/cli.py",
-        ],
+        ["python", "-m", "bankcleanr.cli", "build"],
+        cwd=tmp_path,
         check=True,
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        stdin=subprocess.DEVNULL,
     )
-    exe = dist_dir / (name + (".exe" if system.startswith("win") else ""))
+    exe = tmp_path / "dist" / (name + (".exe" if system.startswith("win") else ""))
     sample_pdf = Path("Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf")
     out_jsonl = tmp_path / "out.jsonl"
     subprocess.run([str(exe), "extract", str(sample_pdf), str(out_jsonl), "--bank", "coop"], check=True)

--- a/tests/test_pyinstaller_schema.py
+++ b/tests/test_pyinstaller_schema.py
@@ -1,41 +1,22 @@
-import subprocess
+import os
 import platform
+import subprocess
 from pathlib import Path
 
 
 def test_schema_bundled_with_pyinstaller(tmp_path):
-    dist_dir = tmp_path / "dist"
-    build_dir = tmp_path / "build"
-    spec_dir = tmp_path / "spec"
     system = platform.system().lower()
     system_label = "macos" if system == "darwin" else system
     machine = platform.machine().lower()
     name = f"bankcleanr-{system_label}-{machine}"
-    sep = ";" if system.startswith("win") else ":"
-    schema = Path("bankcleanr/schemas/transaction_v1.json").resolve()
     subprocess.run(
-        [
-            "pyinstaller",
-            "--name",
-            name,
-            "--onefile",
-            "--add-data",
-            f"{schema}{sep}schemas",
-            "--collect-submodules",
-            "bankcleanr.parsers",
-            "--hidden-import",
-            "bankcleanr.schemas",
-            "--distpath",
-            str(dist_dir),
-            "--workpath",
-            str(build_dir),
-            "--specpath",
-            str(spec_dir),
-            "bankcleanr/cli.py",
-        ],
+        ["python", "-m", "bankcleanr.cli", "build"],
+        cwd=tmp_path,
         check=True,
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        stdin=subprocess.DEVNULL,
     )
-    executable = dist_dir / (name + (".exe" if system.startswith("win") else ""))
+    executable = tmp_path / "dist" / (name + (".exe" if system.startswith("win") else ""))
     assert executable.exists()
     sample_pdf = Path("Redacted bank statements/22b583f5-4060-44eb-a844-945cd612353c (1).pdf")
     out_jsonl = tmp_path / "out.jsonl"


### PR DESCRIPTION
## Summary
- resolve pyinstaller script path to support `bankcleanr build` from any directory
- exercise build via CLI in tests and add BDD coverage

## Testing
- `pytest tests/test_pyinstaller_extract.py tests/test_pyinstaller_schema.py`
- `behave features/build.feature`


------
https://chatgpt.com/codex/tasks/task_e_689a683d2ba0832bb3fe71c232735910