### PR TITLE
feat: add macOS build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,12 @@ For Linux builds you can also run the helper script which performs the build ins
 ./scripts/build_linux.sh
 ```
 
+For macOS builds use the helper script that runs on the host Python interpreter:
+
+```bash
+./scripts/build_macos.sh
+```
+
 macOS and Windows binaries must be built on their respective operating systems.
 
 Install `pyinstaller` first (either via `pip install pyinstaller` or

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pip install . jsonschema pyinstaller
+python -m bankcleanr.cli build


### PR DESCRIPTION
## Summary
- add macOS build script using host Python
- document macOS build helper in README

## Testing
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_689a6e0deecc832baf3b108075524c22