### PR TITLE
feat: warn when no transactions extracted

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -43,12 +43,17 @@ def extract(
     if not mask_names and sys.stdin.isatty():
         mask_names = typer.prompt("Enter comma-separated names to mask", default="")
     names = [n.strip() for n in mask_names.split(",") if n.strip()]
+    count = 0
     with output_jsonl.open("w", encoding="utf-8") as fh:
         for item in extract_transactions(str(input_pdf), bank=bank):
             desc = item.get("description") or ""
             item["description"] = mask_pii(desc, names)
             jsonschema.validate(item, SCHEMA)
             fh.write(json.dumps(item) + "\n")
+            count += 1
+    if count == 0:
+        typer.secho("No transactions extracted", err=True)
+        raise typer.Exit(code=1)
 
 
 # register an alias so older workflows using "parse" still function

--- a/tests/test_cli_no_transactions.py
+++ b/tests/test_cli_no_transactions.py
@@ -1,0 +1,20 @@
+from typer.testing import CliRunner
+
+from bankcleanr import cli
+
+
+def test_cli_exits_when_no_transactions(tmp_path, monkeypatch):
+    runner = CliRunner()
+
+    def fake_extract(pdf_path: str, bank: str = "barclays"):
+        return []
+
+    monkeypatch.setattr(cli, "extract_transactions", fake_extract)
+
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    out = tmp_path / "out.jsonl"
+    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    assert result.exit_code != 0
+    output = result.stdout + result.stderr
+    assert "No transactions extracted" in output


### PR DESCRIPTION
## Summary
- warn and exit when no transactions are extracted
- add CLI test for missing transaction case

## Testing
- `PYTHONPATH=. pytest tests/test_cli_schema_validation.py tests/test_cli_no_transactions.py -q`
- `behave features/placeholder.feature` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689b18454094832ba27a7a9c0f6d5505