### PR TITLE
Use importlib.resources Traversable for Python 3.12

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import platform
 from importlib import resources
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from pathlib import Path
 
 import jsonschema


### PR DESCRIPTION
## Summary
- import Traversable from importlib.resources.abc for Python 3.12+

## Testing
- `pytest tests/test_cli_import.py tests/test_cli_schema_validation.py tests/test_cli_no_transactions.py`
- `python -m py_compile bankcleanr/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3738c70c832b963fcdbd3ca1cd86