### PR TITLE
Raise error when PDF directory is empty

### DIFF
--- a/bankcleanr/extractor.py
+++ b/bankcleanr/extractor.py
@@ -24,6 +24,8 @@ def extract_transactions(
     def _iter() -> Iterator[Dict[str, str | None]]:
         if path.is_dir():
             pdf_files = sorted(path.glob("*.pdf"))
+            if not pdf_files:
+                raise ValueError(f"No PDFs found in directory: {path}")
             for pdf_file in pdf_files:
                 for record in parser.parse(str(pdf_file)):
                     yield record

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -11,3 +11,9 @@ def test_extract_transactions_unknown_bank():
     assert str(excinfo.value) == (
         f"Unsupported bank 'unknown'. Available banks: {available}"
     )
+
+
+def test_extract_transactions_empty_directory(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        list(extract_transactions(tmp_path))
+    assert str(excinfo.value) == f"No PDFs found in directory: {tmp_path}"


### PR DESCRIPTION
## Summary
- raise ValueError when PDF directory contains no statements
- add unit test for empty directory handling

## Testing
- `PYTHONPATH=$PWD pytest tests/test_extractor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3c1b5a20832ba254551aa25d2b66