### PR TITLE
Validate rule labels against taxonomy

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ from rules.engine import (
     norm,
     Match,
     Action,
+    CATEGORIES,
 )
 from backend.llm_adapter import get_adapter, AbstractAdapter
 from bankcleanr.signature import normalise_signature
@@ -152,6 +153,8 @@ def create_rule(
             status_code=400,
             detail="Pattern must contain at least 6 alphabetic characters",
         )
+    if rule.label not in CATEGORIES:
+        raise HTTPException(status_code=400, detail="Unknown category label")
     existing = session.exec(
         select(UserRule)
         .where(UserRule.user_id == rule.user_id)

--- a/rules/engine.py
+++ b/rules/engine.py
@@ -17,6 +17,10 @@ def load_categories(path: Path = CATEGORIES_PATH) -> List[str]:
         return json.load(f)
 
 
+# Preload categories at import time to avoid repeated disk access.
+CATEGORIES: List[str] = load_categories()
+
+
 class Match(BaseModel):
     type: str
     pattern: str

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -79,9 +79,19 @@ def test_upload_gzip(client: TestClient):
 
 
 def test_rules(client: TestClient):
-    client.post("/rules", json={"label": "allow", "pattern": "allowed"})
+    client.post("/rules", json={"label": "Groceries", "pattern": "allowed"})
     rules = client.get("/rules").json()
-    assert any(r["label"] == "allow" for r in rules)
+    assert any(r["label"] == "Groceries" for r in rules)
+
+
+def test_rule_rejects_unknown_label(client: TestClient):
+    resp = client.post("/rules", json={"label": "UnknownLabel", "pattern": "allowed"})
+    assert resp.status_code == 400
+
+
+def test_rule_rejects_short_pattern(client: TestClient):
+    resp = client.post("/rules", json={"label": "Groceries", "pattern": "abc"})
+    assert resp.status_code == 400
 
 
 def test_classify(client: TestClient):


### PR DESCRIPTION
## Summary
- reject user rules with labels outside the category taxonomy
- preload taxonomy categories for quick validation
- test rule creation for taxonomy and pattern length enforcement

## Testing
- `PYTHONPATH=. pytest tests/test_backend_api.py::test_rule_rejects_unknown_label tests/test_backend_api.py::test_rule_rejects_short_pattern tests/test_backend_api.py::test_rules -q`

------
https://chatgpt.com/codex/tasks/task_e_689bbeb8618c832bbf729e5376730845