### PR TITLE
Normalize user rule patterns and enforce taxonomy validation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -175,6 +175,8 @@ def create_rule(
             status_code=400,
             detail="Pattern must contain at least 6 alphabetic characters",
         )
+    # store the normalised pattern so duplicates are matched consistently
+    rule.pattern = normalised
     if rule.label not in CATEGORIES:
         raise HTTPException(status_code=400, detail="Unknown category label")
     existing = session.exec(

--- a/features/backend_api.feature
+++ b/features/backend_api.feature
@@ -6,8 +6,8 @@ Feature: Backend API
 
   Scenario: Managing user rules
     Given the API client
-    When I create a rule "allow all"
-    Then the rules list contains "allow all"
+    When I create a rule "Groceries"
+    Then the rules list contains "Groceries"
 
   Scenario: Downloading with a valid signature
     Given the API client

--- a/rules/engine.py
+++ b/rules/engine.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import json
 import re
 from datetime import datetime
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Union, Set
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -18,7 +18,8 @@ def load_categories(path: Path = CATEGORIES_PATH) -> List[str]:
 
 
 # Preload categories at import time to avoid repeated disk access.
-CATEGORIES: List[str] = load_categories()
+# Stored as a set for efficient membership checks while remaining iterable.
+CATEGORIES: Set[str] = set(load_categories())
 
 
 class Match(BaseModel):

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -96,6 +96,22 @@ def test_rule_rejects_short_pattern(client: TestClient):
     assert resp.status_code == 400
 
 
+def test_rule_rejects_pattern_with_digits(client: TestClient):
+    """Digits and symbols should not count toward the minimum pattern length."""
+    resp = client.post(
+        "/rules", json={"label": "Groceries", "pattern": "ab12cd"}
+    )
+    assert resp.status_code == 400
+
+
+def test_rule_normalises_pattern(client: TestClient):
+    resp = client.post(
+        "/rules", json={"label": "Groceries", "pattern": "Coffee-Shop!"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["pattern"] == "coffeeshop"
+
+
 def test_rule_overwrites_higher_confidence(client: TestClient):
     low = client.post(
         "/rules",


### PR DESCRIPTION
## Summary
- Normalize user rule patterns before storage and ensure labels exist in the canonical taxonomy
- Store taxonomy categories as a set for efficient membership checks
- Extend API tests for taxonomy validation and pattern length enforcement
- Adjust backend API BDD scenario to use a valid taxonomy label

## Testing
- `PYTHONPATH=$PWD pytest tests/test_backend_api.py -q`
- `PYTHONPATH=$PWD pytest tests/test_rules_engine.py -q`
- `PYTHONPATH=$PWD behave features/backend_api.feature`
- `PYTHONPATH=$PWD pytest tests/test_llm_e2e.py -q` *(skipped: RUN_LLM_E2E not set)*

------
https://chatgpt.com/codex/tasks/task_e_689c689b9330832bbfbd983a89f09651