### PR TITLE
Add LLM cost aggregation endpoint and tests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -118,12 +118,13 @@ def costs(
     entries = session.exec(select(LLMCost).where(LLMCost.job_id == job_id)).all()
     tokens_in = sum(e.tokens_in for e in entries)
     tokens_out = sum(e.tokens_out for e in entries)
-    estimated_cost = sum(e.estimated_cost_gbp for e in entries)
+    total_tokens = tokens_in + tokens_out
+    estimated_cost_gbp = sum(e.estimated_cost_gbp for e in entries)
     return {
         "tokens_in": tokens_in,
         "tokens_out": tokens_out,
-        "total_tokens": tokens_in + tokens_out,
-        "estimated_cost_gbp": estimated_cost,
+        "total_tokens": total_tokens,
+        "estimated_cost_gbp": estimated_cost_gbp,
     }
 
 

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -243,7 +243,8 @@ def test_classify_overwrites_higher_confidence_rule(
         assert rule.provenance == "llm"
 
 
-def test_costs_endpoint(client: TestClient):
+def test_costs_endpoint_aggregates_entries(client: TestClient):
+    """Costs endpoint should sum multiple LLMCost rows for a job."""
     job_id = client.post(
         "/upload", data="data", headers={"Content-Type": "text/plain"}
     ).json()["job_id"]
@@ -265,6 +266,7 @@ def test_costs_endpoint(client: TestClient):
             )
         )
         session.commit()
+
     resp = client.get(f"/costs/{job_id}")
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- expose GET `/costs/{job_id}` to aggregate token usage and cost
- track LLM cost in GBP inside adapter
- test cost aggregation logic in backend API

## Testing
- `pytest`
- `pytest tests/test_llm_adapter.py::test_report_cost_recorded tests/test_llm_adapter.py::test_report_cost_limit`
- `PYTHONPATH=. pytest tests/test_backend_api.py::test_costs_endpoint_aggregates_entries`


------
https://chatgpt.com/codex/tasks/task_e_689c7979582c832bb801880d7b8d5c93