### PR TITLE
Add BDD scenario for NDJSON rule auto-learning

### DIFF
--- a/features/rule_auto_learning.feature
+++ b/features/rule_auto_learning.feature
@@ -1,10 +1,16 @@
 Feature: Rule auto-learning
-  Scenario: LLM classification creates a persistent rule
+  Scenario: LLM classification learns and persists a rule from NDJSON
     Given the API client
     And a fake adapter returning label "snacks" with confidence 0.9
-    When I upload text "Corner Shop 123"
-    And I classify with user id 1
-    And I classify with user id 1
+    When I upload NDJSON:
+      """
+      {"description": "Corner Shop 123"}
+      """
+    Then the job status should be "pending"
+    When I classify with user id 1
+    Then the job status should be "completed"
+    And the classification label is "snacks"
+    When I classify with user id 1
     Then the classification label is "snacks"
     And the adapter was called 1 times
     And the rules list contains "snacks"

--- a/features/steps/auto_learning_steps.py
+++ b/features/steps/auto_learning_steps.py
@@ -1,4 +1,4 @@
-from behave import given, then  # type: ignore[import-untyped]
+from behave import given, when, then  # type: ignore[import-untyped]
 
 from features.steps.backend_api_steps import _setup_client, app
 from backend.llm_adapter import AbstractAdapter, get_adapter
@@ -29,3 +29,19 @@ def given_fake_adapter(context, label, conf):
 @then('the adapter was called {n:d} times')
 def then_adapter_called(context, n):
     assert context.fake_adapter.calls == n
+
+
+@when("I upload NDJSON:")
+def when_upload_ndjson(context):
+    if not hasattr(context, "client"):
+        _setup_client(context)
+    resp = context.client.post(
+        "/upload", data=context.text, headers={"Content-Type": "application/x-ndjson"}
+    )
+    context.job_id = resp.json()["job_id"]
+
+
+@then('the job status should be "{status}"')
+def then_job_status_should_be(context, status):
+    resp = context.client.get(f"/status/{context.job_id}")
+    assert resp.json()["status"] == status


### PR DESCRIPTION
## Summary
- cover rule auto-learning when classifying NDJSON uploads
- add steps for uploading NDJSON and asserting job status transitions

## Testing
- `pytest`
- `behave features/rule_auto_learning.feature`


------
https://chatgpt.com/codex/tasks/task_e_689c84bb2870832b8a0c83e203c873fa