### PR TITLE
feat: handle multipart uploads and align status

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,9 +5,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export const JOB_STATUS_UPLOADED = "uploaded";
+
 export async function waitForJobStatus(
   jobId: string,
-  target = "uploaded",
+  target = JOB_STATUS_UPLOADED,
   interval = 1000,
 ): Promise<{ status: string }> {
   while (true) {

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -17,8 +17,11 @@ export default function Upload() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!file) return;
+    const typedFile = new File([file], file.name, {
+      type: 'application/x-ndjson',
+    });
     const formData = new FormData();
-    formData.append('file', file);
+    formData.append('file', typedFile);
     const res = await fetch('/upload', { method: 'POST', body: formData });
     const data = await res.json();
     setJobId(data.job_id);

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -64,10 +64,13 @@ def client_fixture(monkeypatch):
 
 
 def test_upload_and_status(client: TestClient):
-    resp = client.post("/upload", data="hello", headers={"Content-Type": "text/plain"})
+    resp = client.post(
+        "/upload",
+        files={"file": ("test.jsonl", "hello", "text/plain")},
+    )
     job_id = resp.json()["job_id"]
     status = client.get(f"/status/{job_id}").json()["status"]
-    assert status == "pending"
+    assert status == "uploaded"
 
 
 def test_upload_gzip(client: TestClient):


### PR DESCRIPTION
## Summary
- accept multipart uploads on backend and store initial job status as "uploaded"
- send NDJSON files with correct content type from frontend upload page
- share uploaded status constant across frontend utils
- adjust API test for multipart uploads

## Testing
- `poetry run pytest tests/test_backend_api.py`
- `poetry run pytest`
- `poetry run behave` *(fails: undefined step)*
- `cd frontend && npm test -- --headless` *(fails: expected script arguments)*
- `poetry run ruff check backend frontend/src/pages frontend/src/lib tests/test_backend_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca16363d4832ba60b1afd22f10db0