### PR TITLE
Persist and expose classified transactions

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, Any
+
+from sqlalchemy import Column, JSON
 from sqlmodel import SQLModel, Field
 
 
@@ -34,6 +36,15 @@ class ClassificationResult(SQLModel, table=True):
     job_id: int = Field(foreign_key="processingjob.id")
     result: Optional[str] = None
     status: str = Field(default="queued")
+
+
+class Transaction(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    job_id: int = Field(foreign_key="processingjob.id")
+    description: Optional[str] = None
+    data: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    label: Optional[str] = None
+    classification_type: Optional[str] = None
 
 
 class LLMCost(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- add Transaction model to store classified entries
- persist and return labeled transactions in `/classify`
- expose `/transactions/{job_id}` endpoint with filters
- test classification output and transaction retrieval

## Testing
- `PYTHONPATH=. pytest tests/test_backend_api.py::test_classify tests/test_backend_api.py::test_classify_applies_user_rule tests/test_backend_api.py::test_transactions_endpoint_filters tests/test_backend_api.py::test_classify_uses_cache -q`

------
https://chatgpt.com/codex/tasks/task_e_689cae58115c832ba17f38d986826683