### PR TITLE
Handle missing amounts in CLI

### DIFF
--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -48,7 +48,8 @@ def extract(
         for item in extract_transactions(str(input_pdf), bank=bank):
             desc = item.get("description") or ""
             item["description"] = mask_pii(desc, names)
-            amt = float(item.get("amount", 0))
+            amt_raw = item.get("amount")
+            amt = float(amt_raw) if amt_raw is not None else 0.0
             if "type" not in item:
                 item["type"] = "credit" if amt > 0 else "debit"
             jsonschema.validate(item, SCHEMA)

--- a/tests/test_cli_schema_validation.py
+++ b/tests/test_cli_schema_validation.py
@@ -20,6 +20,29 @@ def test_cli_validates_records(tmp_path, monkeypatch):
     assert isinstance(result.exception, ValidationError)
 
 
+def test_cli_handles_missing_amount(tmp_path, monkeypatch):
+    runner = CliRunner()
+
+    def fake_extract(pdf_path: str, bank: str = "barclays"):
+        return [
+            {
+                "date": "01 Jan 2024",
+                "description": "x",
+                "amount": None,
+                "merchant_signature": "",
+            }
+        ]
+
+    monkeypatch.setattr(cli, "extract_transactions", fake_extract)
+
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    out = tmp_path / "out.jsonl"
+    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValidationError)
+
+
 def test_cli_parse_alias(tmp_path, monkeypatch):
     runner = CliRunner()
 


### PR DESCRIPTION
## Summary
- Safely handle missing `amount` values in CLI extraction by defaulting to 0.0 when `None`
- Add unit test confirming records with `None` amounts trigger schema validation but not type errors

## Testing
- `pytest tests/test_cli_schema_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d0ec7a870832bb156bb0d509fde26