### PR TITLE
fix: guard summary endpoint placeholder

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -408,7 +408,7 @@ def create_summary(
 
 @app.get("/summary/{job_id}")
 def get_summary(job_id: int, _: None = Depends(auth_dependency)):
-    json_path, _ = _summary_paths(job_id)
+    json_path, _csv_path = _summary_paths(job_id)
     if not json_path.exists():
         raise HTTPException(status_code=404, detail="Summary not found")
     return json.loads(json_path.read_text())

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -193,7 +193,18 @@ def test_summary_endpoints(client: TestClient, tmp_path: Path):
     resp = client.get(f"/summary/{job_id}")
     assert resp.status_code == 200
     data = resp.json()
-    assert "totals" in data
+    generated_at = data.pop("generated_at")
+    assert isinstance(generated_at, str)
+    assert data == {
+        "job_id": str(job_id),
+        "user_id": "0",
+        "period": {"start": "2024-01-01", "end": "2024-01-02"},
+        "currency": "GBP",
+        "totals": {"income": 5.0, "expenses": -10.0, "net": -5.0},
+        "categories": [],
+        "recurring": [],
+        "highlights": {"overspending": [], "anomalies": []},
+    }
     # regenerate via POST
     (tmp_path / f"{job_id}_summary_v1.json").unlink()
     (tmp_path / f"{job_id}_summary.csv").unlink()


### PR DESCRIPTION
## Summary
- avoid reassigning dependency placeholder in `get_summary`
- verify summary endpoint returns expected JSON after classification

## Testing
- `PYTHONPATH=. pytest tests/test_backend_api.py::test_summary_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_689d103ec238832b9e79ea4e6adb0205