### PR TITLE
Guard description filter and test query params

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -425,7 +425,9 @@ def list_transactions(
     query = select(Transaction).where(Transaction.job_id == job_id)
     if type:
         query = query.where(Transaction.classification_type == type)
-    if description:
-        query = query.where(Transaction.description.contains(description))
+    if description is not None:
+        query = query.where(
+            Transaction.description.contains(str(description))  # type: ignore[attr-defined]
+        )
     entries = session.exec(query).all()
     return [t.data for t in entries]


### PR DESCRIPTION
## Summary
- ensure description filter explicitly checks for None and casts to string before applying SQL contains
- add tests verifying type and description query parameters filter transactions correctly

## Testing
- `PYTHONPATH=. pytest tests/test_backend_api.py::test_transactions_endpoint_filters -q`


------
https://chatgpt.com/codex/tasks/task_e_689d11e047b8832bb024ab7d28b2958f