### PR TITLE
Skip PyInstaller tests when PyInstaller is missing

### DIFF
--- a/tests/test_pyinstaller_extract.py
+++ b/tests/test_pyinstaller_extract.py
@@ -1,8 +1,18 @@
 import json
 import os
 import platform
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
+
+
+if shutil.which("pyinstaller") is None:
+    pytest.skip(
+        "PyInstaller is not installed; skipping PyInstaller integration tests.",
+        allow_module_level=True,
+    )
 
 
 def test_pyinstaller_extract(tmp_path):

--- a/tests/test_pyinstaller_schema.py
+++ b/tests/test_pyinstaller_schema.py
@@ -1,7 +1,17 @@
 import os
 import platform
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
+
+
+if shutil.which("pyinstaller") is None:
+    pytest.skip(
+        "PyInstaller is not installed; skipping PyInstaller integration tests.",
+        allow_module_level=True,
+    )
 
 
 def test_schema_bundled_with_pyinstaller(tmp_path):


### PR DESCRIPTION
## Summary
- Skip PyInstaller integration tests when PyInstaller isn't installed

## Testing
- `pytest tests/test_pyinstaller_extract.py tests/test_pyinstaller_schema.py -rs -q`


------
https://chatgpt.com/codex/tasks/task_e_689d980f2518832b80f171e9192a25f5