### PR TITLE
Ensure transaction type on extraction

### DIFF
--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -17,3 +17,31 @@ def test_extract_transactions_empty_directory(tmp_path):
     with pytest.raises(ValueError) as excinfo:
         list(extract_transactions(tmp_path))
     assert str(excinfo.value) == f"No PDFs found in directory: {tmp_path}"
+
+
+def test_extract_transactions_adds_type(monkeypatch, tmp_path):
+    class DummyParser:
+        def parse(self, pdf_path):  # pragma: no cover - simple helper
+            return [
+                {
+                    "date": "2024-01-01",
+                    "description": "x",
+                    "amount": "+1.00",
+                    "merchant_signature": "sig",
+                }
+            ]
+
+    monkeypatch.setitem(PARSER_REGISTRY, "dummy", DummyParser)
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    records = list(extract_transactions(str(pdf), bank="dummy"))
+    assert records == [
+        {
+            "date": "2024-01-01",
+            "description": "x",
+            "amount": "+1.00",
+            "merchant_signature": "sig",
+            "type": "credit",
+        }
+    ]
+    PARSER_REGISTRY.pop("dummy", None)


### PR DESCRIPTION
## Summary
- Ensure extracted transactions always include a `type` field
- Add regression test for type inference on extraction

## Testing
- `pytest tests/test_extractor.py tests/test_cli_schema_validation.py::test_cli_parse_alias tests/test_parsers.py::test_extract_transactions -vv`

------
https://chatgpt.com/codex/tasks/task_e_68a06020a0f4832bb20c3e8334064cd5