### PR TITLE
feat: display job id on progress page

### DIFF
--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -21,6 +21,11 @@ export default function Progress() {
     <main className="p-4" aria-busy="true">
       <h1 className="text-2xl font-bold">Processing...</h1>
       <p role="status">We are processing your file. This may take a moment.</p>
+      {jobId && (
+        <p>
+          Job ID: <span>{jobId}</span>
+        </p>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show job id on progress page so Cypress journey test can find it after upload

## Testing
- `cd frontend && npm test` *(fails: Install Xvfb and run Cypress again)*

------
https://chatgpt.com/codex/tasks/task_e_68a06b1e40e0832ba31d82879e364f9d