### PR TITLE
Support currency symbols and thousands in bank parsers

### DIFF
--- a/bankcleanr/parsers/barclays.py
+++ b/bankcleanr/parsers/barclays.py
@@ -11,7 +11,7 @@ from ..pii import mask_pii
 from ..signature import normalise_signature
 
 _LINE_RE = re.compile(
-    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?\d+\.\d{2})\s+(-?\d+\.\d{2})$"
+    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})$"
 )
 
 
@@ -28,13 +28,14 @@ class BarclaysParser:
                     if match:
                         date, desc, amount, balance = match.groups()
                         clean_desc = mask_pii(desc.strip())
-                        amt = Decimal(amount)
+                        amt = Decimal(amount.replace("£", "").replace(",", ""))
+                        bal = Decimal(balance.replace("£", "").replace(",", ""))
                         records.append(
                             {
                                 "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
                                 "amount": f"{amt:+.2f}",
-                                "balance": f"{Decimal(balance):+.2f}",
+                                "balance": f"{bal:+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                                 "type": "credit" if amt > 0 else "debit",
                             }

--- a/bankcleanr/parsers/hsbc.py
+++ b/bankcleanr/parsers/hsbc.py
@@ -11,7 +11,7 @@ from ..pii import mask_pii
 from ..signature import normalise_signature
 
 _LINE_RE = re.compile(
-    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?\d+\.\d{2})\s+(-?\d+\.\d{2})$"
+    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})$"
 )
 
 
@@ -28,13 +28,14 @@ class HSBCParser:
                     if match:
                         date, desc, amount, balance = match.groups()
                         clean_desc = mask_pii(desc.strip())
-                        amt = Decimal(amount)
+                        amt = Decimal(amount.replace("£", "").replace(",", ""))
+                        bal = Decimal(balance.replace("£", "").replace(",", ""))
                         records.append(
                             {
                                 "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
                                 "amount": f"{amt:+.2f}",
-                                "balance": f"{Decimal(balance):+.2f}",
+                                "balance": f"{bal:+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                                 "type": "credit" if amt > 0 else "debit",
                             }

--- a/bankcleanr/parsers/lloyds.py
+++ b/bankcleanr/parsers/lloyds.py
@@ -11,7 +11,7 @@ from ..pii import mask_pii
 from ..signature import normalise_signature
 
 _LINE_RE = re.compile(
-    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?\d+\.\d{2})\s+(-?\d+\.\d{2})$"
+    r"^(\d{2} \w{3} \d{4})\s+(.*?)\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})\s+(-?[£]?\d{1,3}(?:,\d{3})*\.\d{2})$"
 )
 
 
@@ -28,13 +28,14 @@ class LloydsParser:
                     if match:
                         date, desc, amount, balance = match.groups()
                         clean_desc = mask_pii(desc.strip())
-                        amt = Decimal(amount)
+                        amt = Decimal(amount.replace("£", "").replace(",", ""))
+                        bal = Decimal(balance.replace("£", "").replace(",", ""))
                         records.append(
                             {
                                 "date": datetime.strptime(date, "%d %b %Y").date().isoformat(),
                                 "description": clean_desc,
                                 "amount": f"{amt:+.2f}",
-                                "balance": f"{Decimal(balance):+.2f}",
+                                "balance": f"{bal:+.2f}",
                                 "merchant_signature": normalise_signature(clean_desc),
                                 "type": "credit" if amt > 0 else "debit",
                             }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -9,6 +9,9 @@ import pytest
 from reportlab.pdfgen import canvas
 
 from bankcleanr.extractor import extract_transactions
+from bankcleanr.parsers.barclays import BarclaysParser
+from bankcleanr.parsers.hsbc import HSBCParser
+from bankcleanr.parsers.lloyds import LloydsParser
 
 SCHEMA = json.loads(
     resources.files("bankcleanr.schemas").joinpath("transaction_v1.json").read_text()
@@ -67,3 +70,28 @@ def test_extract_transactions_directory() -> None:
     records = list(extract_transactions(str(FIXTURE_DIR), bank="coop"))
     expected_count = sum(len(json.load(open(jp))) for _, jp in STATEMENTS)
     assert len(records) == expected_count
+
+
+def _create_pdf(path: Path, lines: list[str]) -> None:
+    c = canvas.Canvas(str(path))
+    text = c.beginText(40, 800)
+    for line in lines:
+        text.textLine(line)
+    c.drawText(text)
+    c.save()
+
+
+@pytest.mark.parametrize("parser_cls", [BarclaysParser, HSBCParser, LloydsParser])
+def test_parse_currency_formats(tmp_path: Path, parser_cls) -> None:
+    pdf_path = tmp_path / "statement.pdf"
+    lines = [
+        "01 Jan 2024 Test £1,234.56 £1,234.56",
+        "02 Jan 2024 Test -£789.00 £445.56",
+    ]
+    _create_pdf(pdf_path, lines)
+    parser = parser_cls()
+    records = parser.parse(str(pdf_path))
+    assert records[0]["amount"] == "+1234.56"
+    assert records[0]["balance"] == "+1234.56"
+    assert records[1]["amount"] == "-789.00"
+    assert records[1]["balance"] == "+445.56"


### PR DESCRIPTION
## Summary
- allow optional currency symbols and comma separators in Barclays, HSBC and Lloyds statement parsing
- strip currency symbols and commas before Decimal conversion
- add regression tests covering `£1,234.56` and `-£789.00`

## Testing
- `pytest tests/test_parsers.py`
- `behave features/extract_barclays.feature features/extract_hsbc.feature features/extract_lloyds.feature` *(skipped: No fixtures for bank barclays, hsbc, lloyds)*

------
https://chatgpt.com/codex/tasks/task_e_68a07fcd7ff0832baf84de140704e75b