### PR TITLE
Add fixtures for UK bank parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ summary.csv
 # Ignore PDF statements
 *.pdf
 !Redacted bank statements/*.pdf
+!tests/fixtures/**/*.pdf
 # Node
 frontend/node_modules/
 frontend/dist/

--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -10,16 +10,25 @@ FIXTURES = {
     "coop": [
         Path("tests/fixtures/coop/statement_1.pdf"),
         Path("tests/fixtures/coop/statement_2.pdf"),
-    ]
+    ],
+    "barclays": [
+        Path("tests/fixtures/barclays/statement_1.pdf"),
+        Path("tests/fixtures/barclays/statement_2.pdf"),
+    ],
+    "hsbc": [
+        Path("tests/fixtures/hsbc/statement_1.pdf"),
+        Path("tests/fixtures/hsbc/statement_2.pdf"),
+    ],
+    "lloyds": [
+        Path("tests/fixtures/lloyds/statement_1.pdf"),
+        Path("tests/fixtures/lloyds/statement_2.pdf"),
+    ],
 }
 
 
 @given("a sample {bank} statement")
 def step_given_sample(context, bank):
-    fixtures = FIXTURES.get(bank)
-    if not fixtures:
-        context.scenario.skip(f"No fixtures for bank {bank}")
-        return
+    fixtures = FIXTURES[bank]
     context.tmpdir = tempfile.TemporaryDirectory()
     fixture = fixtures[0]
     context.pdf_path = os.path.join(context.tmpdir.name, fixture.name)
@@ -76,10 +85,7 @@ def step_then_check(context, count):
 
 @given("multiple {bank} statements")
 def step_given_multiple(context, bank):
-    fixtures = FIXTURES.get(bank)
-    if not fixtures:
-        context.scenario.skip(f"No fixtures for bank {bank}")
-        return
+    fixtures = FIXTURES[bank]
     context.tmpdir = tempfile.TemporaryDirectory()
     context.pdf_dir = context.tmpdir.name
     for fixture in fixtures[:2]:

--- a/tests/fixtures/barclays/statement_1.pdf
+++ b/tests/fixtures/barclays/statement_1.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<ffc5658704729c38d4ac4114ca32ddf8><ffc5658704729c38d4ac4114ca32ddf8>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF

--- a/tests/fixtures/barclays/statement_2.pdf
+++ b/tests/fixtures/barclays/statement_2.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<d0247bff63baaf772fa80eaed67ef695><d0247bff63baaf772fa80eaed67ef695>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF

--- a/tests/fixtures/coop/statement_1.pdf
+++ b/tests/fixtures/coop/statement_1.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131036+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131036+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 314
+>>
+stream
+GarW55u5BP%#+0I(%4,:'U#hum4n"V&dW9<Qm%J'PQRXAT^r+;.gY?8V!,r"@Qup]P)hZ\Nrr2k/ntQd6-iB,83n;_(*$C_BI]-;#o^%,j*p?Mr\3>g`TO;fpHoHCp%f*h!a9"m"`YJh@D-k:E@E=?QV^6t1AsQe8$Xo]Saffn)qR&YV*nM2U!h`K&95u>\4@r5Md4Q,-J52Pk^8)lq!DcfDqfW[e7KXV-15*[[ll@sf,WPUMV?ts.T7Q.`<ef;#6hH?*n:u4Thbpr[R_0Nc/Ze,g+@FG:TH]a>#.f>>0-U\jKHAY"$+).8H~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<11d7bb96a586bcce16ab3b2095b051b4><11d7bb96a586bcce16ab3b2095b051b4>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1241
+%%EOF

--- a/tests/fixtures/coop/statement_2.pdf
+++ b/tests/fixtures/coop/statement_2.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131036+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131036+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 534
+>>
+stream
+GasbWbAQ&g'L_]kMHM8q_32+&7sD=.\Z@5W+IP2p'h.Bf/a@H<!r`%'3NlV.JNs4Oa2)$:),c"6-][6C*`tkDmfZ%5GRoqC*77*n$ecCmB[0IpNk!,@3.*mUp:H(^^<m(X^o-'#4(LI;=,9'P(V"kJ`2Gk\b$n5VAo/a:"O$*i5]m,c/jr-<f4g5'<I>;3hP+([UK\/,f@*VQSkuFgb!4'?-55=5:;PAEDG1_72oMY4,)T?/3nUAPGl\jg<3/c\@<]6]q>Ci9qm@g+ch+it+_'huV'+LK%FIHmcST0,CU%2/6N_?YQ`+%CClUee&!ZMfaXPOl@_IPO[aqrZaib!A&/D7h=0d5?Z"^0%3*hi-/dTYrSEQHn%Ec+f8unDQT"6>gM2gVH!i9?g_4#-]S::cT0Y4C[`#jJDcE4a9-@Ea8"fdoqXI'Z-73-K/g*<Y6<m*K7)Y.IffUCB.8Z"\^c"60K_2fXL\R=tMZ?j^SG_/CtLA5?M@T\C3'BL3,blRs/;Bf<tg%$EhHI]P#$U19W!<~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<0c5870dd25253f4c75356472a0f65dda><0c5870dd25253f4c75356472a0f65dda>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1461
+%%EOF

--- a/tests/fixtures/coop/statement_3.pdf
+++ b/tests/fixtures/coop/statement_3.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131036+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131036+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 537
+>>
+stream
+Garo?c#28i&;9LtME.OD^lT2.T-Gpb0l'?;`,1s5MBI$P"e:eRrn4fAA!mW+#Sd)CB6KS=OSl&pqfrDt$+HIWb!:HL[*YHeNimV6*DnCc8I=,03prX6gYMR7O5IU#WpouEb8-MibW!mUciVi!2aK&S!Kk7[,'%NMBH^qRFU_S;KTX+W,I/d"<d*C&5:sDPWo+Mk<XEnLWBPhOqm`mo(1lh#4Rl#M>pmuGplU"WmX<!m]L@TLe1'OsVJ"Fk'n#&oQV?H]*\c6VFtH0Aq"@hrP>EWt`c_jR-NnQTBX7B8B/S0_j2=S8FER_2k7&ENocb,NU6M!T[!mtW+4F^f]H,SAnVc++;GDtc^-^F3#G"Ma\Bd:R;FtpNfR'lgm2b)Or&gt==mt)dGKZ%%kI&Y?PiP0m#Fp9-76+<D!h,,F#VGGt9bB=sQoqhrq>OsrOrBcIN4*X8Vhl?S=?F3/ABq)s"Qo;-7$/&Pq=4tKM,?J[nk%Q5"ktAZcuI5`HHr[^"e:&s,&kAUmD;CkSUN$eX)[e>aP?F/~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<c6dc8bd54a601a0a993bb56969fdaa60><c6dc8bd54a601a0a993bb56969fdaa60>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1464
+%%EOF

--- a/tests/fixtures/hsbc/statement_1.pdf
+++ b/tests/fixtures/hsbc/statement_1.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<b93246ffc0e7e1b6f2ff6a59b5477bb2><b93246ffc0e7e1b6f2ff6a59b5477bb2>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF

--- a/tests/fixtures/hsbc/statement_2.pdf
+++ b/tests/fixtures/hsbc/statement_2.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<6879d4a9f89fc0272da1037efb716254><6879d4a9f89fc0272da1037efb716254>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF

--- a/tests/fixtures/lloyds/statement_1.pdf
+++ b/tests/fixtures/lloyds/statement_1.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<4eebf072ed0864805b7421baeed913d6><4eebf072ed0864805b7421baeed913d6>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF

--- a/tests/fixtures/lloyds/statement_2.pdf
+++ b/tests/fixtures/lloyds/statement_2.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250816131010+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250816131010+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 170
+>>
+stream
+GaqKg5mkIo$q9nR`ET?M9nj6b/%Q:9bln<B,%=c=](#F5<i?.acf=PP,!J'SEs#WVF\jo&2&aYoS_.0*>^pK&2Bl8@XQi`VS)!^B4<Vd$[BK4M'-tLVG/G*>7QrML?!ZVeFmU5$f;0:_Ln@6KP?as][qml@rJUXh`<XRU/J\~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<e2a8b7ed4812bf0625fca84e99daec9d><e2a8b7ed4812bf0625fca84e99daec9d>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1097
+%%EOF


### PR DESCRIPTION
## Summary
- add PDF fixtures for Barclays, HSBC, Lloyds and Co-op
- include new fixtures in Behave steps and run scenarios
- unignore test fixture PDFs

## Testing
- `behave features/extract_barclays.feature`
- `behave features/extract_hsbc.feature`
- `behave features/extract_lloyds.feature`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0826db394832b99e1cf7958ef9041