### PR TITLE
Require bank flag for CLI extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ can operate on the saved files.
 Run the extractor directly from source or build a self-contained binary:
 
 ```bash
-poetry run bankcleanr extract statement.pdf tx.jsonl
-poetry run bankcleanr parse statement.pdf tx.jsonl  # alias for extract
+poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc
+poetry run bankcleanr parse statement.pdf tx.jsonl --bank hsbc  # alias for extract
 poetry run bankcleanr build
 ```
 
 The `extract` command is also available as `parse` for backwards
 compatibility with existing workflows.
 
-The CLI can also process an entire directory of statements in one go:
+The `--bank` option is required to specify which parser to use. The CLI can also process an entire directory of statements in one go:
 
 ```bash
 bankcleanr extract "My Statements/" tx.jsonl --bank coop
@@ -105,7 +105,7 @@ The extractor ships with parsers for a few UK banks:
 - `hsbc`
 - `lloyds`
 
-Select the appropriate parser with the `--bank` option:
+Select the appropriate parser with the required `--bank` option:
 
 ```bash
 poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -43,9 +43,9 @@ def extract(
     ),
     output_jsonl: Path = typer.Argument(..., help="Output JSONL file"),
     bank: str = typer.Option(
-        "barclays",
+        ...,  # type: ignore[arg-type]
         "--bank",
-        help="Bank identifier (barclays, hsbc, lloyds, coop)",
+        help="Bank identifier (barclays, hsbc, lloyds, coop). Required.",
     ),
     mask_names: str = typer.Option("", "--mask-names", help="Comma-separated names to mask"),
 ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_cli_no_transactions.py
+++ b/tests/test_cli_no_transactions.py
@@ -14,7 +14,20 @@ def test_cli_exits_when_no_transactions(tmp_path, monkeypatch):
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    result = runner.invoke(
+        cli.app, ["extract", str(pdf), str(out), "--bank", "barclays"]
+    )
     assert result.exit_code != 0
     output = result.stdout + result.stderr
     assert "No transactions extracted" in output
+
+
+def test_cli_requires_bank(tmp_path):
+    runner = CliRunner()
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    out = tmp_path / "out.jsonl"
+    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    assert result.exit_code != 0
+    output = result.stdout + result.stderr
+    assert "Missing option '--bank'" in output

--- a/tests/test_cli_schema_validation.py
+++ b/tests/test_cli_schema_validation.py
@@ -15,7 +15,9 @@ def test_cli_validates_records(tmp_path, monkeypatch):
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    result = runner.invoke(
+        cli.app, ["extract", str(pdf), str(out), "--bank", "barclays"]
+    )
     assert result.exit_code != 0
     assert isinstance(result.exception, ValidationError)
 
@@ -38,7 +40,9 @@ def test_cli_handles_missing_amount(tmp_path, monkeypatch):
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    result = runner.invoke(
+        cli.app, ["extract", str(pdf), str(out), "--bank", "barclays"]
+    )
     assert result.exit_code != 0
     assert isinstance(result.exception, ValidationError)
 
@@ -62,7 +66,9 @@ def test_cli_parse_alias(tmp_path, monkeypatch):
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(cli.app, ["parse", str(pdf), str(out)])
+    result = runner.invoke(
+        cli.app, ["parse", str(pdf), str(out), "--bank", "barclays"]
+    )
     assert result.exit_code == 0
     assert (
         out.read_text()


### PR DESCRIPTION
## Summary
- make `--bank` a required option for the CLI extractor
- document required `--bank` usage in README
- add tests covering missing bank handling and update existing CLI tests

## Testing
- `pytest tests/test_cli_no_transactions.py`


------
https://chatgpt.com/codex/tasks/task_e_68a084e1fe74832b9a30e1afbcffe433