### PR TITLE
Canonicalize paths when signing URLs

### DIFF
--- a/backend/signing.py
+++ b/backend/signing.py
@@ -4,9 +4,26 @@ import hashlib
 import hmac
 import os
 import time
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 
 SECRET_KEY = os.environ.get("SIGNING_SECRET_KEY", "changeme")
+
+
+def _canonicalize_path(path: str) -> str:
+    """Return a normalised representation of ``path``.
+
+    The HMAC signature should not depend on superfluous path decorations such
+    as ``..`` segments or percent-encoded characters.  This helper decodes any
+    percent escapes and collapses redundant path components using
+    :func:`os.path.normpath`.
+    """
+
+    normalized = os.path.normpath(unquote(path))
+    # Ensure the path always starts with a slash to avoid ``normpath`` removing
+    # it for relative paths.
+    if not normalized.startswith("/"):
+        normalized = "/" + normalized
+    return normalized
 
 
 def generate_signed_url(path: str, expires_in: int = 3600) -> str:
@@ -19,6 +36,7 @@ def generate_signed_url(path: str, expires_in: int = 3600) -> str:
     Returns:
         The path with appended query parameters "expires" and "signature".
     """
+    path = _canonicalize_path(path)
     expiry = int(time.time()) + expires_in
     msg = f"{path}:{expiry}".encode()
     signature = hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).hexdigest()
@@ -43,6 +61,7 @@ def verify_signed_url(path: str, expires: int, signature: str) -> bool:
     except (TypeError, ValueError):
         return False
 
+    path = _canonicalize_path(path)
     msg = f"{path}:{expires_int}".encode()
     expected = hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).hexdigest()
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -26,3 +26,13 @@ def test_tampered_url_fails():
     path, expires, signature = _parse(url)
     # Tamper with the path after signing
     assert not verify_signed_url("/download/2/summary", expires, signature)
+
+
+def test_path_normalisation_is_consistent():
+    """Both generation and verification should normalise paths."""
+    url = generate_signed_url("/download/1/../1/summary", expires_in=60)
+    path, expires, signature = _parse(url)
+    # The generated URL should contain the normalised path
+    assert path == "/download/1/summary"
+    # Verification should also normalise incoming paths
+    assert verify_signed_url("/download/./1/summary", expires, signature)


### PR DESCRIPTION
## Summary
- normalize URL paths to a canonical form before generating or verifying signatures
- ensure both signing and verification use the same canonical representation
- add regression test covering path normalization

## Testing
- `pytest tests/test_signing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfb4e528832b9c842812e65cba93