### PR TITLE
Add Windows build script and parser auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Run the extractor directly from source or build a self-contained binary:
 
 ```bash
 poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc
+poetry run bankcleanr extract statement.pdf tx.jsonl           # auto-detect bank
 poetry run bankcleanr parse statement.pdf tx.jsonl --bank hsbc  # alias for extract
 poetry run bankcleanr build
 ```
@@ -78,7 +79,9 @@ poetry run bankcleanr build
 The `extract` command is also available as `parse` for backwards
 compatibility with existing workflows.
 
-The `--bank` option is required to specify which parser to use. The CLI can also process an entire directory of statements in one go:
+The `--bank` option can be used to specify which parser to use, or omitted to
+let the extractor detect the bank automatically. The CLI can also process an
+entire directory of statements in one go:
 
 ```bash
 bankcleanr extract "My Statements/" tx.jsonl --bank coop
@@ -104,8 +107,10 @@ The extractor ships with parsers for a few UK banks:
 - `coop` (separate `Moneyout` and `Moneyin` columns)
 - `hsbc`
 - `lloyds`
+- `auto` (detect from statement)
 
-Select the appropriate parser with the required `--bank` option:
+Select the appropriate parser with the `--bank` option or omit it for
+auto-detection:
 
 ```bash
 poetry run bankcleanr extract statement.pdf tx.jsonl --bank hsbc
@@ -285,6 +290,12 @@ For macOS builds use the helper script that runs on the host Python interpreter:
 
 ```bash
 ./scripts/build_macos.sh
+```
+
+For Windows builds use the PowerShell script:
+
+```powershell
+./scripts/build_windows.ps1
 ```
 
 macOS and Windows binaries must be built on their respective operating systems.

--- a/bankcleanr/cli.py
+++ b/bankcleanr/cli.py
@@ -42,10 +42,12 @@ def extract(
         help="Path to a PDF file or directory of PDFs",
     ),
     output_jsonl: Path = typer.Argument(..., help="Output JSONL file"),
-    bank: str = typer.Option(
-        ...,  # type: ignore[arg-type]
+    bank: str | None = typer.Option(
+        None,  # type: ignore[arg-type]
         "--bank",
-        help="Bank identifier (barclays, hsbc, lloyds, coop). Required.",
+        help=(
+            "Bank identifier (barclays, hsbc, lloyds, coop) or 'auto' to detect from the statement."
+        ),
     ),
     mask_names: str = typer.Option("", "--mask-names", help="Comma-separated names to mask"),
 ) -> None:

--- a/bankcleanr/parsers/__init__.py
+++ b/bankcleanr/parsers/__init__.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from typing import Dict, Type
+import re
+from typing import Dict, Iterable, Type
+
+import pdfplumber
 
 PARSER_REGISTRY: Dict[str, Type] = {}
 
@@ -24,4 +27,29 @@ def _load_parsers() -> Dict[str, Type]:
 
 PARSER_REGISTRY = _load_parsers()
 
-__all__ = [cls.__name__ for cls in PARSER_REGISTRY.values()] + ["PARSER_REGISTRY"]
+
+_DETECT_PATTERNS: Dict[str, Iterable[re.Pattern[str]]] = {
+    "hsbc": [re.compile(r"hsbc", re.I)],
+    "lloyds": [re.compile(r"lloyds", re.I)],
+    "coop": [re.compile(r"co-?operative", re.I), re.compile(r"co-?op", re.I)],
+    "barclays": [re.compile(r"barclays", re.I)],
+}
+
+
+def detect_bank(pdf_path: str) -> str:
+    """Return the bank identifier for ``pdf_path``.
+
+    Inspect the full text of the PDF and look for bank specific keywords.
+    Currently recognises HSBC, Lloyds, Co-op and Barclays statements.
+    """
+
+    with pdfplumber.open(pdf_path) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+    for bank, patterns in _DETECT_PATTERNS.items():
+        for pattern in patterns:
+            if pattern.search(text):
+                return bank
+    raise ValueError("Unable to detect bank for PDF")
+
+
+__all__ = [cls.__name__ for cls in PARSER_REGISTRY.values()] + ["PARSER_REGISTRY", "detect_bank"]

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,5 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+
+pip install . jsonschema pyinstaller
+python -m bankcleanr.cli build

--- a/tests/test_cli_no_transactions.py
+++ b/tests/test_cli_no_transactions.py
@@ -6,7 +6,7 @@ from bankcleanr import cli
 def test_cli_exits_when_no_transactions(tmp_path, monkeypatch):
     runner = CliRunner()
 
-    def fake_extract(pdf_path: str, bank: str = "barclays"):
+    def fake_extract(pdf_path: str, bank: str | None = None):
         return []
 
     monkeypatch.setattr(cli, "extract_transactions", fake_extract)
@@ -14,20 +14,24 @@ def test_cli_exits_when_no_transactions(tmp_path, monkeypatch):
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(
-        cli.app, ["extract", str(pdf), str(out), "--bank", "barclays"]
-    )
+    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
     assert result.exit_code != 0
     output = result.stdout + result.stderr
     assert "No transactions extracted" in output
 
 
-def test_cli_requires_bank(tmp_path):
+def test_cli_allows_missing_bank(tmp_path, monkeypatch):
     runner = CliRunner()
+    called: dict[str, str | None] = {}
+
+    def fake_extract(pdf_path: str, bank: str | None = None):
+        called["bank"] = bank
+        return []
+
+    monkeypatch.setattr(cli, "extract_transactions", fake_extract)
+
     pdf = tmp_path / "in.pdf"
     pdf.write_bytes(b"%PDF-1.4")
     out = tmp_path / "out.jsonl"
-    result = runner.invoke(cli.app, ["extract", str(pdf), str(out)])
-    assert result.exit_code != 0
-    output = result.stdout + result.stderr
-    assert "Missing option '--bank'" in output
+    runner.invoke(cli.app, ["extract", str(pdf), str(out)])
+    assert called["bank"] is None

--- a/tests/test_cli_parsers_via_cli.py
+++ b/tests/test_cli_parsers_via_cli.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from bankcleanr import cli
+
+FIXTURES = [
+    ("hsbc", Path("tests/fixtures/hsbc/statement_1.pdf")),
+    ("lloyds", Path("tests/fixtures/lloyds/statement_1.pdf")),
+    ("coop", Path("tests/fixtures/coop/statement_1.pdf")),
+    ("barclays", Path("tests/fixtures/barclays/statement_1.pdf")),
+]
+
+
+@pytest.mark.parametrize("bank,pdf_path", FIXTURES)
+def test_cli_parses_each_bank(bank: str, pdf_path: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = tmp_path / "out.jsonl"
+    result = runner.invoke(
+        cli.app, ["extract", str(pdf_path), str(out), "--bank", bank]
+    )
+    assert result.exit_code == 0
+    lines = out.read_text().strip().splitlines()
+    assert lines
+    for line in lines:
+        record = json.loads(line)
+        assert record["date"]
+        assert record["amount"].startswith(("+", "-"))
+        assert record["type"] in {"credit", "debit"}

--- a/tests/test_cli_schema_validation.py
+++ b/tests/test_cli_schema_validation.py
@@ -7,7 +7,7 @@ from bankcleanr import cli
 def test_cli_validates_records(tmp_path, monkeypatch):
     runner = CliRunner()
 
-    def fake_extract(pdf_path: str, bank: str = "barclays"):
+    def fake_extract(pdf_path: str, bank: str | None = None):
         return [{"date": "01 Jan 2024", "description": "x", "type": "credit"}]  # missing amount
 
     monkeypatch.setattr(cli, "extract_transactions", fake_extract)
@@ -25,7 +25,7 @@ def test_cli_validates_records(tmp_path, monkeypatch):
 def test_cli_handles_missing_amount(tmp_path, monkeypatch):
     runner = CliRunner()
 
-    def fake_extract(pdf_path: str, bank: str = "barclays"):
+    def fake_extract(pdf_path: str, bank: str | None = None):
         return [
             {
                 "date": "01 Jan 2024",
@@ -50,7 +50,7 @@ def test_cli_handles_missing_amount(tmp_path, monkeypatch):
 def test_cli_parse_alias(tmp_path, monkeypatch):
     runner = CliRunner()
 
-    def fake_extract(pdf_path: str, bank: str = "barclays"):
+    def fake_extract(pdf_path: str, bank: str | None = None):
         return [
             {
                 "date": "01 Jan 2024",

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -7,7 +7,7 @@ from bankcleanr.parsers import PARSER_REGISTRY
 def test_extract_transactions_unknown_bank():
     available = ", ".join(sorted(PARSER_REGISTRY))
     with pytest.raises(ValueError) as excinfo:
-        extract_transactions("dummy.pdf", bank="unknown")
+        list(extract_transactions("dummy.pdf", bank="unknown"))
     assert str(excinfo.value) == (
         f"Unsupported bank 'unknown'. Available banks: {available}"
     )


### PR DESCRIPTION
## Summary
- add Windows PowerShell build script
- support auto bank detection with optional `--bank`
- document new build and parser options; test CLI parsers

## Testing
- `python -m pytest tests/test_cli_parsers_via_cli.py tests/test_cli_no_transactions.py tests/test_cli_schema_validation.py tests/test_extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0e7ed7784832baa29cf5d5bd99460