### PR TITLE
Add placeholder parser fixture for CLI tests

### DIFF
--- a/features/steps/extract_steps.py
+++ b/features/steps/extract_steps.py
@@ -23,6 +23,9 @@ FIXTURES = {
         Path("tests/fixtures/lloyds/statement_1.pdf"),
         Path("tests/fixtures/lloyds/statement_2.pdf"),
     ],
+    "placeholder": [
+        Path("tests/fixtures/placeholder/statement_1.pdf"),
+    ],
 }
 
 

--- a/tests/fixtures/placeholder/statement_1.pdf
+++ b/tests/fixtures/placeholder/statement_1.pdf
@@ -1,0 +1,1 @@
+placeholder fixture pdf


### PR DESCRIPTION
## Summary
- register placeholder bank fixture so CLI tests can load sample statements
- include placeholder PDF fixture for behave tests

## Testing
- `poetry run ruff check features/steps/extract_steps.py`
- `poetry run pytest tests/test_rules_engine.py`
- `poetry run behave features/placeholder.feature`


------
https://chatgpt.com/codex/tasks/task_e_68a0e731df04832bbd63826c6b23761d