### PR TITLE
Include taxonomy data in API Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install poetry \
 COPY backend ./backend
 COPY bankcleanr ./bankcleanr
 COPY rules ./rules
+COPY data ./data
 
 # Document which port the FastAPI app listens on
 EXPOSE 8000

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+
+def test_api_dockerfile_copies_data():
+    dockerfile = Path("Dockerfile").read_text()
+    assert re.search(r"^COPY\s+data\s+\.\/data\s*$", dockerfile, re.MULTILINE), (
+        "Dockerfile must copy the data directory so taxonomy files are available in the API container"
+    )


### PR DESCRIPTION
## Summary
- ensure API Dockerfile copies taxonomy data directory
- add test to check Dockerfile includes taxonomy assets

## Testing
- `poetry run pytest tests/test_taxonomy.py tests/test_dockerfile.py -q`
- `poetry run behave` *(fails: features/backend_api.feature:32 Generating summaries)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bbd97790832b84b4d41237557bff