### PR TITLE
fix: update rule auto-learning tests for category validation

### DIFF
--- a/features/rule_auto_learning.feature
+++ b/features/rule_auto_learning.feature
@@ -1,7 +1,7 @@
 Feature: Rule auto-learning
   Scenario: LLM classification learns and persists a rule from NDJSON
     Given the API client
-    And a fake adapter returning label "snacks" with confidence 0.9
+    And a fake adapter returning label "Groceries" with confidence 0.9
     When I upload NDJSON:
       """
       {"description": "Corner Shop 123", "type": "debit"}
@@ -9,14 +9,14 @@ Feature: Rule auto-learning
     Then the job status should be "uploaded"
     When I classify with user id 1
     Then the job status should be "completed"
-    And the classification label is "snacks"
+    And the classification label is "Groceries"
     When I classify with user id 1
-    Then the classification label is "snacks"
-    And the rules list contains "snacks"
+    Then the classification label is "Groceries"
+    And the rules list contains "Groceries"
 
   Scenario: Learned rule applied to subsequent upload
     Given the API client
-    And a fake adapter returning label "snacks" with confidence 0.9
+    And a fake adapter returning label "Groceries" with confidence 0.9
     When I upload NDJSON:
       """
       {"description": "Corner Shop 123", "type": "debit"}
@@ -24,7 +24,7 @@ Feature: Rule auto-learning
     Then the job status should be "uploaded"
     When I classify with user id 1
     Then the job status should be "completed"
-    And the classification label is "snacks"
+    And the classification label is "Groceries"
     Given the signature cache is cleared
     When I upload NDJSON:
       """
@@ -32,5 +32,5 @@ Feature: Rule auto-learning
       """
     Then the job status should be "uploaded"
     When I classify with user id 1
-    Then the classification label is "snacks"
-    And the rules list contains "snacks"
+    Then the classification label is "Groceries"
+    And the rules list contains "Groceries"

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -192,7 +192,7 @@ def test_low_confidence_prevents_auto_rule(monkeypatch):
             super().__init__("test")
 
         def _send(self, prompts):
-            return {"labels": [("snacks", 0.5)] * len(prompts), "usage": {"total_tokens": 0}}
+            return {"labels": [("Groceries", 0.5)] * len(prompts), "usage": {"total_tokens": 0}}
 
     adapter = LowConfAdapter()
     app.dependency_overrides[get_session] = get_session_override


### PR DESCRIPTION
## Summary
- use canonical category "Groceries" in rule_auto_learning.feature
- adjust low-confidence adapter test to return valid category

## Testing
- `poetry run pytest tests/test_llm_adapter.py tests/test_backend_api.py`
- `poetry run behave features/rule_auto_learning.feature`


------
https://chatgpt.com/codex/tasks/task_e_68a1d74e5a54832b92236d6569ce5483