### PR TITLE
feat: move jsonschema to main dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -53,7 +53,7 @@ version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
     {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
@@ -1464,7 +1464,7 @@ version = "4.25.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716"},
     {file = "jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f"},
@@ -1486,7 +1486,7 @@ version = "2025.4.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af"},
     {file = "jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"},
@@ -2758,7 +2758,7 @@ version = "0.36.2"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -2975,7 +2975,7 @@ version = "0.26.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "rpds_py-0.26.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:4c70c70f9169692b36307a95f3d8c0a9fcd79f7b4a383aad5eaa0e9718b79b37"},
     {file = "rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:777c62479d12395bfb932944e61e915741e364c843afc3196b694db3d669fcd0"},
@@ -4076,4 +4076,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "2fe76805bf1f92001e952d85295d5363b4e80473bea8d9609758082a305302ff"
+content-hash = "1f8aeffda971c7524f2eece39a3c9b62b55a4cbbb914f11e68d385662126c178"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ sqlmodel = "^0.0.16"
 uvicorn = "^0.30.0"
 rapidfuzz = "^3.6.1"
 weasyprint = "^62.0"
+jsonschema = "^4.21.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
@@ -32,7 +33,6 @@ reportlab = "^4.4.2"
 ruff = "^0.12.5"
 mypy = "^1.10.0"
 pytest-cov = "^5.0.0"
-jsonschema = "^4.21.1"
 types-jsonschema = "^4.25.0.20250720"
 types-reportlab = "^4.4.1.20250602"
 pyinstaller = {version = "^6.14", markers = "python_version < '3.14'"}


### PR DESCRIPTION
## Summary
- make jsonschema a runtime dependency
- refresh poetry.lock

## Testing
- `poetry run pytest -k "not pyinstaller"`
- `poetry run behave` *(fails: Aborted by user request)*
- `podman compose build api` *(fails: open `/proc/sys/net/ipv4/ping_group_range`: Read-only file system)*
- `podman compose up --build api frontend` *(fails: short-name "dogshit_api" did not resolve to an alias and no unqualified-search registries are defined)*
- `poetry run python scripts/demo.py "Redacted bank statements" --api http://localhost:8000 --user 1` *(fails: httpx.ConnectError: [Errno 111] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f4a136c832bb9541ad62a52fcd5