### PR TITLE
Expose OpenAI key for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ command line interface and a small test-suite.
    cd frontend && npm install && cd ..
    ```
 
-2. Start the API and Vite dev server:
+2. Start the API and Vite dev server (set your OpenAI key first):
 
    ```bash
-   docker compose up --build api frontend
+   export OPENAI_API_KEY=sk-your-key
+   podman compose up --build api frontend
    ```
 
 Open <http://localhost:5173> and follow the three-click flow (some steps are still manual):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: .
     environment:
       - APP_ENV=prod
+      - LLM_PROVIDER=openai
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:
       - "8000:8000"
   frontend:


### PR DESCRIPTION
## Summary
- Expose LLM provider and API key in `docker-compose.yml`
- Document exporting `OPENAI_API_KEY` before running `podman compose`

## Testing
- `make test` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b71c228832b82c468ecf81dfd65