### PR TITLE
Use adapter dependency override in auto learning tests

### DIFF
--- a/features/steps/auto_learning_steps.py
+++ b/features/steps/auto_learning_steps.py
@@ -1,7 +1,8 @@
 from behave import given, when, then  # type: ignore[import-untyped]
 
 from features.steps.backend_api_steps import _setup_client, app
-from backend.llm_adapter import AbstractAdapter, get_adapter
+from backend.llm_adapter import AbstractAdapter
+from backend.app import get_adapter_dependency
 
 
 @given('a fake adapter returning label "{label}" with confidence {conf:f}')
@@ -23,7 +24,7 @@ def given_fake_adapter(context, label, conf):
     def adapter_override():
         return context.fake_adapter
 
-    app.dependency_overrides[get_adapter] = adapter_override
+    app.dependency_overrides[get_adapter_dependency] = adapter_override
 
 
 @then('the adapter was called {n:d} times')


### PR DESCRIPTION
## Summary
- replace get_adapter dependency override to import from backend.app
- override classification adapter using get_adapter_dependency

## Testing
- `pytest`
- `behave`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5daf7e0832ba9521622a58ad23a