### PR TITLE
Reset LLM_PROVIDER after adapter tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,15 @@
+import os
+import backend.llm_adapter as llm_adapter
+
+
+def after_scenario(context, scenario):
+    try:
+        prev = context.prev_llm_provider
+    except AttributeError:
+        return
+    if prev is None:
+        os.environ.pop("LLM_PROVIDER", None)
+    else:
+        os.environ["LLM_PROVIDER"] = prev
+    llm_adapter._adapter_instances.clear()
+    del context.prev_llm_provider

--- a/features/llm_adapter.feature
+++ b/features/llm_adapter.feature
@@ -3,3 +3,6 @@ Feature: LLM provider selection
     Given the environment variable LLM_PROVIDER is set to "anthropic"
     When requesting an LLM adapter
     Then the adapter type is "AnthropicAdapter"
+
+  Scenario: Environment variable cleaned up after scenario
+    Then the environment variable LLM_PROVIDER is unset

--- a/features/steps/llm_adapter_steps.py
+++ b/features/steps/llm_adapter_steps.py
@@ -5,6 +5,7 @@ import backend.llm_adapter as llm_adapter
 
 @given('the environment variable LLM_PROVIDER is set to "{provider}"')
 def set_provider(context, provider):
+    context.prev_llm_provider = os.environ.get("LLM_PROVIDER")
     os.environ["LLM_PROVIDER"] = provider
     llm_adapter._adapter_instances.clear()
 
@@ -18,3 +19,8 @@ def request_adapter(context):
 def check_adapter_type(context, cls_name):
     cls = getattr(llm_adapter, cls_name)
     assert isinstance(context.adapter, cls)
+
+
+@then("the environment variable LLM_PROVIDER is unset")
+def check_provider_unset(context):
+    assert "LLM_PROVIDER" not in os.environ


### PR DESCRIPTION
## Summary
- preserve current `LLM_PROVIDER` before test changes
- restore the environment variable and clear cached adapters after each scenario
- verify provider cleanup with a dedicated feature scenario

## Testing
- `pytest tests/test_llm_adapter.py tests/test_backend_api.py`
- `behave features/llm_adapter.feature`


------
https://chatgpt.com/codex/tasks/task_e_68a59fcce974832bbbc4727e82b66582