### PR TITLE
Ensure FakeAdapter override after client setup

### DIFF
--- a/features/steps/auto_learning_steps.py
+++ b/features/steps/auto_learning_steps.py
@@ -16,9 +16,9 @@ def given_fake_adapter(context, label, conf):
             self.calls += 1
             return {"labels": [(label, conf)] * len(prompts), "usage": {"total_tokens": 0}}
 
+    context.fake_adapter = FakeAdapter()
     if not hasattr(context, "client"):
         _setup_client(context)
-    context.fake_adapter = FakeAdapter()
     context.preserve_client = True
 
     def adapter_override():


### PR DESCRIPTION
## Summary
- Instantiate FakeAdapter before setting up client and apply override after setup to guarantee classification uses the fake adapter.

## Testing
- `poetry run pytest tests/test_backend_api.py`
- `poetry run behave features/rule_auto_learning.feature`


------
https://chatgpt.com/codex/tasks/task_e_68a5a3aae4dc832bb1d8e3ecf3c0d630