### PR TITLE
Copy schemas directory into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY backend ./backend
 COPY bankcleanr ./bankcleanr
 COPY rules ./rules
 COPY data ./data
+COPY schemas ./schemas
 
 # Document which port the FastAPI app listens on
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- include schemas directory in Docker image

## Testing
- `poetry run pytest`
- `BUILDAH_ISOLATION=chroot podman compose build api` *(fails: SSL certificate verify failed)*
- `BUILDAH_ISOLATION=chroot podman compose up -d api` *(fails: SSL certificate verify failed)
- `poetry run python scripts/demo.py 'Redacted bank statements'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a713b6eac0832ba1b1fdf142c4c819