### PR TITLE
Improve demo scripts and add auth test

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -95,8 +95,12 @@ def main() -> None:
             print("Token usage reduced on second run – learning successful.")
         else:
             print("Token usage did not decrease; ensure caching is enabled.")
-
         print("Fetched", len(_txs2), "classified transactions.")
+        with open("classified_transactions.json", "w", encoding="utf-8") as f:
+            json.dump(_txs2, f, indent=2)
+        print("Sample classified transactions:")
+        print(json.dumps(_txs2[:5], indent=2))
+        print("Full results written to classified_transactions.json")
 
 
 if __name__ == "__main__":

--- a/tests/test_manual_api_demo.py
+++ b/tests/test_manual_api_demo.py
@@ -1,0 +1,57 @@
+"""Tests for the manual API demo script."""
+
+from __future__ import annotations
+
+import types
+from scripts import manual_api_demo
+
+
+class DummyResponse:
+    def __init__(self, json_data=None, text: str = "", content: bytes = b"") -> None:
+        self._json = json_data or {}
+        self.text = text
+        self.content = content
+
+    def raise_for_status(self) -> None:  # pragma: no cover - always success
+        return
+
+    def json(self):  # noqa: D401 - mimic requests.Response
+        return self._json
+
+
+def test_manual_api_demo_includes_auth_header(monkeypatch, tmp_path):
+    """Ensure the demo adds the auth header when calling the API."""
+
+    calls = {"post": [], "get": []}
+
+    def fake_post(url, data=None, json=None, headers=None):
+        calls["post"].append({"url": url, "headers": headers})
+        if url.endswith("/upload"):
+            return DummyResponse({"job_id": 1})
+        if url.endswith("/classify"):
+            return DummyResponse()
+        return DummyResponse()
+
+    def fake_get(url, headers=None):
+        calls["get"].append({"url": url, "headers": headers})
+        if url.endswith("/report/1"):
+            return DummyResponse({"url": "/download/1/report"})
+        if "summary" in url:
+            return DummyResponse(text="{}")
+        if "download/1/report" in url:
+            return DummyResponse(content=b"pdf")
+        return DummyResponse()
+
+    monkeypatch.setattr(
+        manual_api_demo, "requests", types.SimpleNamespace(post=fake_post, get=fake_get)
+    )
+
+    report_path = tmp_path / "report.pdf"
+    monkeypatch.setattr(manual_api_demo, "Path", lambda name: report_path)
+
+    manual_api_demo.main()
+
+    upload_headers = calls["post"][0]["headers"]
+    assert upload_headers and "X-Auth-Token" in upload_headers
+    assert report_path.exists()
+


### PR DESCRIPTION
## Summary
- send auth token with manual API demo and preserve report download
- dump sample classified transactions in end-to-end demo
- add unit test ensuring manual API demo authenticates requests

## Testing
- `poetry run ruff check scripts/manual_api_demo.py scripts/demo.py tests/test_manual_api_demo.py`
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_68a7600e6c18832bb320846702f57583