### PR TITLE
Include category field in transaction classification and summary

### DIFF
--- a/rules/engine.py
+++ b/rules/engine.py
@@ -121,7 +121,17 @@ def _match_text(text: str, match: Match) -> bool:
     return False
 
 
-def evaluate(data: Union[str, dict], rules: Iterable[Rule]) -> Optional[str]:
+def evaluate(
+    data: Union[str, dict], rules: Iterable[Rule]
+) -> Optional[tuple[str, str]]:
+    """Return both the label and category for matching rule.
+
+    Previously this helper only returned a single string representing the
+    category.  Rules now differentiate between an optional ``label`` and a
+    canonical ``category``.  To support this we return a tuple of
+    ``(label, category)`` when a rule matches, or ``None`` if no rule applies.
+    """
+
     if isinstance(data, str):
         record = {"description": data}
     else:
@@ -132,5 +142,7 @@ def evaluate(data: Union[str, dict], rules: Iterable[Rule]) -> Optional[str]:
         for field in rule.match.fields:
             value = record.get(field, "")
             if isinstance(value, str) and _match_text(value, rule.match):
-                return rule.action.label or rule.action.category
+                label = rule.action.label or rule.action.category
+                category = rule.action.category
+                return label, category
     return None

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -156,6 +156,8 @@ def test_classify(client: TestClient):
     data = resp.json()["transactions"]
     labels = [r["label"] for r in data]
     assert labels == ["unknown", "unknown"]
+    categories = [r["category"] for r in data]
+    assert categories == ["unknown", "unknown"]
     assert all(r["type"] == "debit" for r in data)
     # ensure the job status is updated once processing is complete
     status = client.get(f"/status/{job_id}").json()["status"]
@@ -210,7 +212,14 @@ def test_summary_endpoints(client: TestClient, tmp_path: Path):
         "period": {"start": "2024-01-01", "end": "2024-01-02"},
         "currency": "GBP",
         "totals": {"income": 5.0, "expenses": -10.0, "net": -5.0},
-        "categories": [],
+        "categories": [
+            {
+                "name": "Groceries",
+                "total": -10.0,
+                "count": 1,
+                "sample_merchants": ["coffee"],
+            }
+        ],
         "recurring": [],
         "highlights": {"overspending": [], "anomalies": []},
     }

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -120,10 +120,22 @@ def test_match_strategies():
                           match={"type": "signature", "pattern": "CoffeeShop", "fields": ["description"]},
                           action={"label": "signature", "category": "Groceries"})
 
-    assert evaluate({"description": "Coffee Shop"}, [exact_rule]) == "exact"
-    assert evaluate({"description": "my coffee"}, [contains_rule]) == "contains"
-    assert evaluate({"description": "Coffee beans"}, [regex_rule]) == "regex"
-    assert evaluate({"description": "coffee-shop"}, [signature_rule]) == "signature"
+    assert evaluate({"description": "Coffee Shop"}, [exact_rule]) == (
+        "exact",
+        "Groceries",
+    )
+    assert evaluate({"description": "my coffee"}, [contains_rule]) == (
+        "contains",
+        "Groceries",
+    )
+    assert evaluate({"description": "Coffee beans"}, [regex_rule]) == (
+        "regex",
+        "Groceries",
+    )
+    assert evaluate({"description": "coffee-shop"}, [signature_rule]) == (
+        "signature",
+        "Groceries",
+    )
 
 
 def test_field_selection():
@@ -131,7 +143,7 @@ def test_field_selection():
                 match={"type": "contains", "pattern": "acme", "fields": ["counterparty"]},
                 action={"label": "vendor", "category": "Fees"})
     data = {"description": "paycheck", "counterparty": "ACME Corp"}
-    assert evaluate(data, [rule]) == "vendor"
+    assert evaluate(data, [rule]) == ("vendor", "Fees")
 
 
 def test_evaluate_uses_precedence():
@@ -143,5 +155,5 @@ def test_evaluate_uses_precedence():
              match={"type": "contains", "pattern": "shop", "fields": ["description"]},
              action={"label": "high", "category": "Utilities"}),
     ]
-    label = evaluate("coffee shop", merge_rules(rules, []))
-    assert label == "high"
+    result = evaluate("coffee shop", merge_rules(rules, []))
+    assert result == ("high", "Utilities")


### PR DESCRIPTION
## Summary
- Return label and category from `rules.engine.evaluate`
- Persist category in classification results and summaries
- Test that classifications and summaries expose category information

## Testing
- `pytest tests/test_rules_engine.py tests/test_backend_api.py::test_classify tests/test_backend_api.py::test_summary_endpoints -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a81dcf1d50832b88670a23f28458dc