### PR TITLE
Fetch and display analysis results on results page

### DIFF
--- a/frontend/cypress/journey.spec.ts
+++ b/frontend/cypress/journey.spec.ts
@@ -18,7 +18,13 @@ describe('user can upload file and reach results', () => {
     }).as('status');
     cy.intercept('POST', '/classify', {}).as('classify');
     cy.intercept('GET', '/download/123/summary', { body: 'summary' });
-    cy.intercept('GET', '/download/123/details', { body: 'details' });
+    cy.intercept('GET', '/download/123/report', { body: 'report' });
+    cy.intercept('GET', '/summary/123', {
+      totals: { income: 0, expenses: 0, net: 0 },
+      categories: [],
+      recurring: [],
+    });
+    cy.intercept('GET', '/transactions/123', []);
 
     const filePath = 'cypress/fixtures/sample.jsonl';
     cy.get('input[type="file"]').selectFile(filePath);
@@ -33,7 +39,7 @@ describe('user can upload file and reach results', () => {
 
     cy.url().should('include', '/results/123');
     cy.contains('a', /summary/i).should('be.visible');
-    cy.contains('a', /details/i).should('be.visible');
+    cy.contains('a', /report/i).should('be.visible');
   });
 });
 

--- a/frontend/cypress/results.spec.ts
+++ b/frontend/cypress/results.spec.ts
@@ -1,0 +1,20 @@
+describe('results page summary', () => {
+  it('renders summary table and download links', () => {
+    cy.intercept('GET', '/summary/123', {
+      totals: { income: 100, expenses: 50, net: 50 },
+      categories: [{ name: 'Food', total: 20, count: 2 }],
+      recurring: [{ merchant: 'Gym', cadence: 'monthly', avg_amount: 30, count: 3 }],
+    });
+    cy.intercept('GET', '/transactions/123', [
+      { date: '2024-01-01', description: 'Coffee', amount: 3, type: 'debit' },
+    ]);
+    cy.visit('/results/123');
+    cy.get('a[href="/download/123/summary"]').should('exist');
+    cy.get('a[href="/download/123/report"]').should('exist');
+    cy.contains('td', 'Income').next().should('contain', '100');
+    cy.contains('td', 'Expenses').next().should('contain', '50');
+    cy.contains('td', 'Net').next().should('contain', '50');
+    cy.contains('td', 'Food').should('be.visible');
+    cy.contains('td', 'Coffee').should('be.visible');
+  });
+});

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -1,7 +1,64 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+
+interface Totals {
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+interface CategoryBreakdown {
+  name: string;
+  total: number;
+  count: number;
+}
+
+interface RecurringCharge {
+  merchant: string;
+  cadence: string;
+  avg_amount: number;
+  count: number;
+}
+
+interface Summary {
+  totals: Totals;
+  categories: CategoryBreakdown[];
+  recurring?: RecurringCharge[];
+}
+
+export interface Transaction {
+  date: string;
+  description: string;
+  amount: number;
+  type: string;
+  category?: string;
+  label?: string;
+}
 
 export default function Results() {
   const { jobId } = useParams();
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+  useEffect(() => {
+    async function loadData() {
+      const [summaryRes, txRes] = await Promise.all([
+        fetch(`/summary/${jobId}`),
+        fetch(`/transactions/${jobId}`),
+      ]);
+
+      if (summaryRes.ok) {
+        setSummary(await summaryRes.json());
+      }
+      if (txRes.ok) {
+        setTransactions(await txRes.json());
+      }
+    }
+    if (jobId) {
+      loadData();
+    }
+  }, [jobId]);
+
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Results</h1>
@@ -14,13 +71,105 @@ export default function Results() {
           Download Summary
         </a>
         <a
-          href={`/download/${jobId}/details`}
+          href={`/download/${jobId}/report`}
           className="rounded-md bg-blue-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           download
         >
-          Download Details
+          Download Report
         </a>
       </div>
+
+      {summary && (
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Summary</h2>
+          <table className="min-w-full text-left">
+            <tbody>
+              <tr>
+                <td className="pr-4">Income</td>
+                <td>{summary.totals.income}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">Expenses</td>
+                <td>{summary.totals.expenses}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">Net</td>
+                <td>{summary.totals.net}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3 className="text-lg font-semibold">Categories</h3>
+          <table className="min-w-full text-left">
+            <thead>
+              <tr>
+                <th className="pr-4">Name</th>
+                <th className="pr-4">Total</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.categories.map((cat) => (
+                <tr key={cat.name}>
+                  <td className="pr-4">{cat.name}</td>
+                  <td className="pr-4">{cat.total}</td>
+                  <td>{cat.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {summary.recurring && summary.recurring.length > 0 && (
+            <>
+              <h3 className="text-lg font-semibold">Recurring Charges</h3>
+              <table className="min-w-full text-left">
+                <thead>
+                  <tr>
+                    <th className="pr-4">Merchant</th>
+                    <th className="pr-4">Cadence</th>
+                    <th className="pr-4">Avg Amount</th>
+                    <th>Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.recurring.map((r) => (
+                    <tr key={r.merchant}>
+                      <td className="pr-4">{r.merchant}</td>
+                      <td className="pr-4">{r.cadence}</td>
+                      <td className="pr-4">{r.avg_amount}</td>
+                      <td>{r.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Transactions</h2>
+        <table className="min-w-full text-left">
+          <thead>
+            <tr>
+              <th className="pr-4">Date</th>
+              <th className="pr-4">Description</th>
+              <th className="pr-4">Amount</th>
+              <th>Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((tx, idx) => (
+              <tr key={idx}>
+                <td className="pr-4">{tx.date}</td>
+                <td className="pr-4">{tx.description}</td>
+                <td className="pr-4">{tx.amount}</td>
+                <td>{tx.type}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- fetch summary and transaction data on results page and show totals, categories, recurring charges, and transactions
- replace "details" download link with report link
- cover results page with Cypress tests verifying summary table and download links

## Testing
- `npm test` *(fails: Install Xvfb and run Cypress again)*
- `pytest tests/test_backend_api.py::test_summary_endpoints`


------
https://chatgpt.com/codex/tasks/task_e_68a82ffb0434832ba9aa6fda52148475