### PR TITLE
feat: display typed user rules

### DIFF
--- a/frontend/cypress/rules.spec.ts
+++ b/frontend/cypress/rules.spec.ts
@@ -1,0 +1,26 @@
+describe('rules list', () => {
+  it('renders rule details without [object Object]', () => {
+    cy.intercept('GET', '/rules', [
+      {
+        id: 1,
+        user_id: 1,
+        label: 'Food',
+        pattern: 'Coffee',
+        match_type: 'contains',
+        field: 'description',
+        priority: 0,
+        confidence: 1,
+        version: 1,
+        provenance: 'user',
+        updated_at: '2024-01-01T00:00:00Z',
+      },
+    ]);
+    cy.visit('/');
+    cy.get('li')
+      .first()
+      .should('contain', 'Coffee')
+      .and('contain', 'Food')
+      .and('not.contain', '[object Object]');
+  });
+});
+

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,14 @@
+export interface UserRule {
+  id?: number;
+  user_id?: number;
+  label: string;
+  pattern: string;
+  match_type: string;
+  field: string;
+  priority: number;
+  confidence: number;
+  version: number;
+  provenance: string;
+  updated_at: string;
+}
+

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Button } from '../components/ui/button';
 import { waitForJobStatus } from '../lib/utils';
+import type { UserRule } from '../lib/types';
 
 export default function Upload() {
   const [file, setFile] = useState<File | null>(null);
-  const [rules, setRules] = useState<string[]>([]);
+  const [rules, setRules] = useState<UserRule[]>([]);
   const [jobId, setJobId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -66,7 +67,9 @@ export default function Upload() {
         </h2>
         <ul className="list-disc pl-4">
           {rules.map((r) => (
-            <li key={r}>{r}</li>
+            <li key={r.id ?? r.pattern}>
+              {r.pattern} → {r.label}
+            </li>
           ))}
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- type upload page's rules as `UserRule[]` and show pattern and label
- add `UserRule` interface matching backend model
- test that rule information renders without `[object Object]`

## Testing
- `pytest`
- `npm test` *(fails: /root/.cache/Cypress/13.7.3/Cypress/Cypress: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a831920a80832ba9df78f8092c257e