### PR TITLE
feat: show costs and job status

### DIFF
--- a/frontend/cypress/journey.spec.ts
+++ b/frontend/cypress/journey.spec.ts
@@ -25,6 +25,12 @@ describe('user can upload file and reach results', () => {
       recurring: [],
     });
     cy.intercept('GET', '/transactions/123', []);
+    cy.intercept('GET', '/costs/123', {
+      tokens_in: 1,
+      tokens_out: 2,
+      total_tokens: 3,
+      estimated_cost_gbp: 0.01,
+    });
 
     const filePath = 'cypress/fixtures/sample.jsonl';
     cy.get('input[type="file"]').selectFile(filePath);
@@ -40,6 +46,7 @@ describe('user can upload file and reach results', () => {
     cy.url().should('include', '/results/123');
     cy.contains('a', /summary/i).should('be.visible');
     cy.contains('a', /report/i).should('be.visible');
+    cy.contains('td', 'Estimated Cost').next().should('contain', '0.01');
   });
 });
 

--- a/frontend/cypress/results.spec.ts
+++ b/frontend/cypress/results.spec.ts
@@ -8,6 +8,12 @@ describe('results page summary', () => {
     cy.intercept('GET', '/transactions/123', [
       { date: '2024-01-01', description: 'Coffee', amount: 3, type: 'debit' },
     ]);
+    cy.intercept('GET', '/costs/123', {
+      tokens_in: 10,
+      tokens_out: 20,
+      total_tokens: 30,
+      estimated_cost_gbp: 0.5,
+    });
     cy.visit('/results/123');
     cy.get('a[href="/download/123/summary"]').should('exist');
     cy.get('a[href="/download/123/report"]').should('exist');
@@ -16,5 +22,6 @@ describe('results page summary', () => {
     cy.contains('td', 'Net').next().should('contain', '50');
     cy.contains('td', 'Food').should('be.visible');
     cy.contains('td', 'Coffee').should('be.visible');
+    cy.contains('td', 'Estimated Cost').next().should('contain', '0.5');
   });
 });

--- a/frontend/src/pages/Progress.tsx
+++ b/frontend/src/pages/Progress.tsx
@@ -1,26 +1,36 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export default function Progress() {
   const { jobId } = useParams();
   const navigate = useNavigate();
 
+  const [status, setStatus] = useState<string>('uploaded');
+
   useEffect(() => {
     const interval = setInterval(async () => {
       const res = await fetch(`/status/${jobId}`);
       const data = await res.json();
+      setStatus(data.status);
       if (data.status === 'completed') {
         clearInterval(interval);
         navigate(`/results/${jobId}`);
+      }
+      if (data.status === 'failed') {
+        clearInterval(interval);
       }
     }, 1000);
     return () => clearInterval(interval);
   }, [jobId, navigate]);
 
   return (
-    <main className="p-4" aria-busy="true">
+    <main className="p-4" aria-busy={status !== 'failed' && status !== 'completed'}>
       <h1 className="text-2xl font-bold">Processing...</h1>
-      <p role="status">We are processing your file. This may take a moment.</p>
+      {status === 'failed' ? (
+        <p role="alert">Processing failed. Please try again.</p>
+      ) : (
+        <p role="status">Current status: {status}</p>
+      )}
       {jobId && (
         <p>
           Job ID: <span>{jobId}</span>

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -39,12 +39,22 @@ export default function Results() {
   const { jobId } = useParams();
   const [summary, setSummary] = useState<Summary | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [costs, setCosts] = useState<
+    | {
+        tokens_in: number;
+        tokens_out: number;
+        total_tokens: number;
+        estimated_cost_gbp: number;
+      }
+    | null
+  >(null);
 
   useEffect(() => {
     async function loadData() {
-      const [summaryRes, txRes] = await Promise.all([
+      const [summaryRes, txRes, costRes] = await Promise.all([
         fetch(`/summary/${jobId}`),
         fetch(`/transactions/${jobId}`),
+        fetch(`/costs/${jobId}`),
       ]);
 
       if (summaryRes.ok) {
@@ -52,6 +62,9 @@ export default function Results() {
       }
       if (txRes.ok) {
         setTransactions(await txRes.json());
+      }
+      if (costRes.ok) {
+        setCosts(await costRes.json());
       }
     }
     if (jobId) {
@@ -78,6 +91,32 @@ export default function Results() {
           Download Report
         </a>
       </div>
+
+      {costs && (
+        <section>
+          <h2 className="text-xl font-semibold">Costs</h2>
+          <table className="min-w-full text-left">
+            <tbody>
+              <tr>
+                <td className="pr-4">Tokens In</td>
+                <td>{costs.tokens_in}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">Tokens Out</td>
+                <td>{costs.tokens_out}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">Total Tokens</td>
+                <td>{costs.total_tokens}</td>
+              </tr>
+              <tr>
+                <td className="pr-4">Estimated Cost</td>
+                <td>{costs.estimated_cost_gbp}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      )}
 
       {summary && (
         <section className="space-y-4">


### PR DESCRIPTION
## Summary
- show status transitions and failure messaging on progress screen
- expose cost metrics in results screen via /costs/{job_id}
- cover cost info with Cypress tests

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `pytest tests/test_backend_api.py::test_costs_endpoint_aggregates_entries`


------
https://chatgpt.com/codex/tasks/task_e_68a83ad76804832b8346e862e9527b99