### PR TITLE
Ensure OpenAI E2E test runs with API key

### DIFF
--- a/tests/test_llm_e2e.py
+++ b/tests/test_llm_e2e.py
@@ -1,14 +1,16 @@
+import os
 import pytest
 
 from backend.llm_adapter import OpenAIAdapter
+from backend.database import init_db
 
 
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
 def test_openai_e2e():
-    import os
-
-    if not os.getenv("RUN_LLM_E2E"):
-        pytest.skip("RUN_LLM_E2E not set")
+    init_db()
     adapter = OpenAIAdapter()
     out = adapter.classify(["hello"], job_id=1)
     assert isinstance(out, list)
-    assert out[0]["label"]
+    assert out[0]["label"].strip(), "label should not be empty"


### PR DESCRIPTION
## Summary
- Adjust OpenAI E2E test to skip only when `OPENAI_API_KEY` is missing
- Initialize database and assert non-empty labels from OpenAI responses

## Testing
- `pytest tests/test_llm_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99f00cde4832ba5d0dc5e11b92cef