### PR TITLE
refactor: render rule list text explicitly

### DIFF
--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -68,7 +68,7 @@ export default function Upload() {
         <ul className="list-disc pl-4">
           {rules.map((r) => (
             <li key={r.id ?? r.pattern}>
-              {r.pattern} → {r.label}
+              {`${r.pattern} → ${r.label}`}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- format rule list items as `${pattern} → ${label}` to avoid rendering full objects

## Testing
- `npm test` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2a3db4c832b9517d714ad6de38f