### PR TITLE
fix: run frontend dev server on explicit port

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ command line interface and a small test-suite.
    podman compose up --build api frontend
    ```
 
-Open <http://localhost:5173> and follow the three-click flow (some steps are still manual):
+Open <http://localhost:5174> and follow the three-click flow (some steps are still manual):
 
 1. **Download** the desktop extractor from the project's [GitHub releases](https://github.com/OWNER/REPO/releases) page.
 2. **Upload** the generated `transaction_v1.jsonl` file to `/upload` using `Content-Type: application/x-ndjson`, then trigger `/classify` and `/summary/{job_id}` manually until this is automated.
@@ -278,7 +278,7 @@ frontend dev server alongside it with:
 docker compose up frontend
 ```
 
-The Vite dev server will then be available on port 5173 while the API continues
+The Vite dev server will then be available on port 5174 while the API continues
 to listen on port 8000.
 
 When starting with an empty database run the import script once to seed the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
     volumes:
       - ./frontend:/app
     ports:
-      - "5173:5173"
+      - "5174:5174"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      test: ["CMD", "curl", "-f", "http://localhost:5174"]
       interval: 5s
       timeout: 10s
       retries: 5
@@ -28,7 +28,7 @@ services:
       dockerfile: Dockerfile.e2e
     working_dir: /app
     environment:
-      - CYPRESS_BASE_URL=http://frontend:5173
+      - CYPRESS_BASE_URL=http://frontend:5174
     entrypoint: ["npx", "cypress", "run"]
     depends_on:
       frontend:

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:5173',
+    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:5174',
     supportFile: false,
     specPattern: 'cypress/**/*.spec.ts',
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --port 5174",
     "build": "vite build",
     "preview": "vite preview",
     "cypress:run": "cypress run",
-    "test": "start-server-and-test dev http://localhost:5173 cypress:run"
+    "test": "CYPRESS_BASE_URL=http://localhost:5174 start-server-and-test dev http://localhost:5174 cypress:run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './cypress',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:5174',
     headless: true,
   },
   webServer: {
     command: 'npm run dev',
-    port: 5173,
+    port: 5174,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true, // or '0.0.0.0'
-    port: 5173,
+    port: 5174,
     strictPort: true,
     allowedHosts,
   }


### PR DESCRIPTION
## Summary
- run Vite dev server on port 5174 and update Cypress/Playwright configs
- adjust docker-compose and tests to use the new port
- document new dev server port in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9a3b74788832b9c3055e0c12118aa