### PR TITLE
Fetch signed download URLs for results page

### DIFF
--- a/frontend/cypress/results.spec.ts
+++ b/frontend/cypress/results.spec.ts
@@ -14,9 +14,15 @@ describe('results page summary', () => {
       total_tokens: 30,
       estimated_cost_gbp: 0.5,
     });
+    cy.intercept('GET', '/report/123', {
+      url: '/download/123/report?sig=r123',
+    });
+    cy.intercept('GET', '/download/123/summary', {
+      url: '/download/123/summary?sig=s123',
+    });
     cy.visit('/results/123');
-    cy.get('a[href="/download/123/summary"]').should('exist');
-    cy.get('a[href="/download/123/report"]').should('exist');
+    cy.get('a[href="/download/123/summary?sig=s123"]').should('exist');
+    cy.get('a[href="/download/123/report?sig=r123"]').should('exist');
     cy.contains('td', 'Income').next().should('contain', '100');
     cy.contains('td', 'Expenses').next().should('contain', '50');
     cy.contains('td', 'Net').next().should('contain', '50');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './cypress',
+  testDir: './playwright',
   use: {
     baseURL: 'http://localhost:5174',
     headless: true,

--- a/frontend/playwright/downloads.spec.ts
+++ b/frontend/playwright/downloads.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+test('signed download links trigger downloads', async ({ page }) => {
+  await page.route('**/summary/123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        totals: { income: 100, expenses: 50, net: 50 },
+        categories: [],
+      }),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+  await page.route('**/transactions/123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify([]),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+  await page.route('**/costs/123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        tokens_in: 0,
+        tokens_out: 0,
+        total_tokens: 0,
+        estimated_cost_gbp: 0,
+      }),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+
+  await page.route('**/report/123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ url: '/download/123/report?sig=r123' }),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+  await page.route('**/download/123/summary', (route) =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ url: '/download/123/summary?sig=s123' }),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+
+  await page.route('**/download/123/report?sig=r123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: 'pdf',
+      headers: {
+        'content-type': 'application/pdf',
+        'content-disposition': 'attachment; filename="report.pdf"',
+      },
+    }),
+  );
+  await page.route('**/download/123/summary?sig=s123', (route) =>
+    route.fulfill({
+      status: 200,
+      body: 'summary',
+      headers: {
+        'content-type': 'text/plain',
+        'content-disposition': 'attachment; filename="summary.txt"',
+      },
+    }),
+  );
+
+  await page.goto('/results/123');
+
+  const [summaryDownload] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByText('Download Summary').click(),
+  ]);
+  expect(summaryDownload.suggestedFilename()).toContain('summary');
+
+  const [reportDownload] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByText('Download Report').click(),
+  ]);
+  expect(reportDownload.suggestedFilename()).toContain('report');
+});
+

--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -48,6 +48,8 @@ export default function Results() {
       }
     | null
   >(null);
+  const [summaryUrl, setSummaryUrl] = useState<string | null>(null);
+  const [reportUrl, setReportUrl] = useState<string | null>(null);
 
   const linkClasses =
     'rounded-md bg-blue-600 px-4 py-2 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500';
@@ -75,19 +77,39 @@ export default function Results() {
     }
   }, [jobId]);
 
+  useEffect(() => {
+    async function loadUrls() {
+      const [reportRes, summaryRes] = await Promise.all([
+        fetch(`/report/${jobId}`),
+        fetch(`/download/${jobId}/summary`),
+      ]);
+      if (reportRes.ok) {
+        const data = await reportRes.json();
+        setReportUrl(data.url);
+      }
+      if (summaryRes.ok) {
+        const data = await summaryRes.json();
+        setSummaryUrl(data.url);
+      }
+    }
+    if (jobId) {
+      loadUrls();
+    }
+  }, [jobId]);
+
   return (
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Results</h1>
       <div className="flex gap-4">
         <a
-          href={`/download/${jobId}/summary`}
+          href={summaryUrl ?? '#'}
           className={linkClasses}
           download
         >
           Download Summary
         </a>
         <a
-          href={`/download/${jobId}/report`}
+          href={reportUrl ?? '#'}
           className={linkClasses}
           download
         >


### PR DESCRIPTION
## Summary
- sign `GET /download/{job_id}/summary` when no signature provided
- fetch signed summary/report URLs on results page
- add Cypress and Playwright tests for download links

## Testing
- `pytest`
- `npx playwright test`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9adc1fd0c832b847c90df1dbe0866