### PR TITLE
feat(frontend): add rules feedback page

### DIFF
--- a/frontend/playwright/feedback.spec.ts
+++ b/frontend/playwright/feedback.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test('submitting rule feedback posts to /feedback', async ({ page }) => {
+  await page.route('**/rules', (route) => {
+    if (route.request().resourceType() === 'document') {
+      return route.continue();
+    }
+    return route.fulfill({
+      status: 200,
+      body: JSON.stringify([
+        {
+          id: 1,
+          label: 'Food',
+          pattern: 'Tesco',
+          match_type: 'contains',
+          field: 'description',
+          priority: 1,
+          confidence: 1,
+          version: 1,
+          provenance: 'test',
+          updated_at: 'now',
+        },
+      ]),
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+
+  await page.route('**/feedback', (route) =>
+    route.fulfill({ status: 200 }),
+  );
+
+  const feedbackRequest = page.waitForRequest('**/feedback');
+
+  await page.goto('/rules');
+  await page.getByLabel('Suggestion').fill('Groceries');
+  await page.getByRole('button', { name: 'Suggest correction' }).click();
+
+  const request = await feedbackRequest;
+  expect(request.method()).toBe('POST');
+  expect(request.postDataJSON()).toEqual({
+    rule_id: 1,
+    suggestion: 'Groceries',
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,21 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Upload from './pages/Upload';
 import Progress from './pages/Progress';
 import Results from './pages/Results';
+import Rules from './pages/Rules';
 
 export default function App() {
   return (
     <BrowserRouter>
+      <nav aria-label="Main navigation" className="p-4 space-x-4">
+        <Link to="/">Upload</Link>
+        <Link to="/rules">Rules</Link>
+      </nav>
       <Routes>
         <Route path="/" element={<Upload />} />
         <Route path="/progress/:jobId" element={<Progress />} />
         <Route path="/results/:jobId" element={<Results />} />
+        <Route path="/rules" element={<Rules />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Rules.test.tsx
+++ b/frontend/src/pages/Rules.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import Rules from './Rules';
+
+const mockRules = [
+  {
+    id: 1,
+    label: 'Food',
+    pattern: 'Tesco',
+    match_type: 'contains',
+    field: 'description',
+    priority: 1,
+    confidence: 1,
+    version: 1,
+    provenance: 'test',
+    updated_at: 'now',
+  },
+];
+
+describe('Rules page', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn((url: RequestInfo, opts?: RequestInit) => {
+      if (url === '/rules') {
+        return Promise.resolve(
+          new Response(JSON.stringify(mockRules), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      if (url === '/feedback') {
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }
+      return Promise.reject(new Error('unknown url'));
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('validates empty suggestion', async () => {
+    render(<Rules />);
+    const button = await screen.findByRole('button', {
+      name: /suggest correction/i,
+    });
+    fireEvent.click(button);
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Suggestion is required',
+    );
+    // only initial /rules fetch
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+  });
+
+  it('submits suggestion to /feedback', async () => {
+    render(<Rules />);
+    const input = await screen.findByLabelText('Suggestion');
+    fireEvent.change(input, { target: { value: 'Groceries' } });
+    const button = screen.getByRole('button', { name: /suggest correction/i });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/feedback',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+});

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import type { UserRule } from '../lib/types';
+import { Button } from '../components/ui/button';
+
+export default function Rules() {
+  const [rules, setRules] = useState<UserRule[]>([]);
+  const [suggestions, setSuggestions] = useState<Record<number, string>>({});
+  const [errors, setErrors] = useState<Record<number, string>>({});
+  const [submitted, setSubmitted] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    fetch('/rules')
+      .then((r) => r.json())
+      .then(setRules)
+      .catch(() => setRules([]));
+  }, []);
+
+  const handleSubmit = async (
+    e: React.FormEvent<HTMLFormElement>,
+    rule: UserRule,
+  ) => {
+    e.preventDefault();
+    const id = rule.id ?? 0;
+    const suggestion = suggestions[id]?.trim() ?? '';
+    if (!suggestion) {
+      setErrors((prev) => ({ ...prev, [id]: 'Suggestion is required' }));
+      return;
+    }
+    setErrors((prev) => ({ ...prev, [id]: '' }));
+    await fetch('/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rule_id: rule.id, suggestion }),
+    });
+    setSubmitted((prev) => ({ ...prev, [id]: true }));
+    setSuggestions((prev) => ({ ...prev, [id]: '' }));
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Rules</h1>
+      <ul className="space-y-4">
+        {rules.map((rule) => (
+          <li key={rule.id ?? rule.pattern} className="space-y-2">
+            <p>{`${rule.pattern} → ${rule.label}`}</p>
+            <form
+              onSubmit={(e) => handleSubmit(e, rule)}
+              className="space-y-2"
+              aria-label={`Suggest correction for rule ${rule.pattern}`}
+            >
+              <div>
+                <label
+                  htmlFor={`suggestion-${rule.id}`}
+                  className="block font-medium"
+                >
+                  Suggestion
+                </label>
+                <input
+                  id={`suggestion-${rule.id}`}
+                  type="text"
+                  value={suggestions[rule.id ?? 0] ?? ''}
+                  onChange={(e) =>
+                    setSuggestions((prev) => ({
+                      ...prev,
+                      [rule.id ?? 0]: e.target.value,
+                    }))
+                  }
+                  className="mt-1 block w-full rounded border p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label="Suggestion"
+                />
+              </div>
+              {errors[rule.id ?? 0] && (
+                <p role="alert" className="text-red-600">
+                  {errors[rule.id ?? 0]}
+                </p>
+              )}
+              <Button type="submit">Suggest correction</Button>
+              {submitted[rule.id ?? 0] && (
+                <p role="status" className="text-green-600">
+                  Thanks for your feedback!
+                </p>
+              )}
+            </form>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,5 +18,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
## Summary
- add /rules page with per-rule feedback form posting to /feedback
- wire up /rules route and navigation entry
- cover feedback form with unit and Playwright tests

## Testing
- `npm run test:unit`
- `npx playwright test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c4d5233c832b9f0d1c4bcaa787ed