### PR TITLE
feat: add home page and navigation

### DIFF
--- a/frontend/playwright/navigation.spec.ts
+++ b/frontend/playwright/navigation.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('home navigation to upload and rules', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Upload' }).first().click();
+  await expect(page).toHaveURL(/\/upload$/);
+  await page.goBack();
+  await page.getByRole('link', { name: 'Rules' }).first().click();
+  await expect(page).toHaveURL(/\/rules$/);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import NavBar from './components/NavBar';
+import Home from './pages/Home';
 import Upload from './pages/Upload';
 import Progress from './pages/Progress';
 import Results from './pages/Results';
@@ -7,12 +9,10 @@ import Rules from './pages/Rules';
 export default function App() {
   return (
     <BrowserRouter>
-      <nav aria-label="Main navigation" className="p-4 space-x-4">
-        <Link to="/">Upload</Link>
-        <Link to="/rules">Rules</Link>
-      </nav>
+      <NavBar />
       <Routes>
-        <Route path="/" element={<Upload />} />
+        <Route path="/" element={<Home />} />
+        <Route path="/upload" element={<Upload />} />
         <Route path="/progress/:jobId" element={<Progress />} />
         <Route path="/results/:jobId" element={<Results />} />
         <Route path="/rules" element={<Rules />} />

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NavBar from './NavBar';
+import '@testing-library/jest-dom';
+
+describe('NavBar component', () => {
+  it('Given the NavBar is rendered, when viewed, then it shows links and placeholders', () => {
+    render(
+      <MemoryRouter>
+        <NavBar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /upload/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /rules/i })).toBeInTheDocument();
+    expect(screen.getByText(/results/i)).toBeInTheDocument();
+    expect(screen.getByText(/progress/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /results/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /progress/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export default function NavBar() {
+  return (
+    <nav aria-label="Main navigation" className="p-4 space-x-4 bg-gray-100">
+      <Link to="/" className="font-semibold">Home</Link>
+      <Link to="/upload" className="font-semibold">Upload</Link>
+      <Link to="/rules" className="font-semibold">Rules</Link>
+      <span className="text-gray-400">Results</span>
+      <span className="text-gray-400">Progress</span>
+    </nav>
+  );
+}

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import Home from './Home';
+
+describe('Home page', () => {
+  it('Given a visitor, when they view the home page, then they see proposition, instructions and navigation buttons', () => {
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /understand your spending/i }),
+    ).toBeInTheDocument();
+    const bankcleanr = screen.getByRole('link', { name: /bankcleanr/i });
+    expect(bankcleanr).toHaveAttribute('href', 'https://bankcleanr.uwu.ai/');
+    expect(screen.getByRole('link', { name: /^upload$/i })).toHaveAttribute(
+      'href',
+      '/upload',
+    );
+    expect(screen.getByRole('link', { name: /rules/i })).toHaveAttribute(
+      'href',
+      '/rules',
+    );
+  });
+});

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom';
+
+export default function Home() {
+  return (
+    <main>
+      <section className="bg-blue-50 text-center py-20 px-4">
+        <h1 className="text-4xl font-bold mb-4">Understand your spending</h1>
+        <p className="text-lg mb-8">
+          Turn bank statements into actionable financial insights.
+        </p>
+        <div className="space-x-4">
+          <Link to="/upload" className="px-6 py-3 rounded bg-blue-600 text-white hover:bg-blue-700">
+            Upload
+          </Link>
+          <Link to="/rules" className="px-6 py-3 rounded bg-gray-200 text-gray-800 hover:bg-gray-300">
+            Rules
+          </Link>
+        </div>
+      </section>
+      <section className="py-12 px-4 max-w-3xl mx-auto text-center">
+        <h2 className="text-2xl font-semibold mb-4">Get started in three steps</h2>
+        <ol className="list-decimal list-inside text-left space-y-2">
+          <li>
+            Clean your CSV using{' '}
+            <a
+              href="https://bankcleanr.uwu.ai/"
+              className="text-blue-600 underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Bankcleanr
+            </a>
+            .
+          </li>
+          <li>Upload the file to categorize transactions.</li>
+          <li>Explore insights and refine rules.</li>
+        </ol>
+      </section>
+      <section className="bg-gray-50 py-12">
+        <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-6 text-center">
+          <div className="p-6">
+            <h3 className="font-semibold mb-2">Automatic categorization</h3>
+            <p>Our rules engine groups your transactions instantly.</p>
+          </div>
+          <div className="p-6">
+            <h3 className="font-semibold mb-2">Track spending</h3>
+            <p>Visualize where your money goes each month.</p>
+          </div>
+          <div className="p-6">
+            <h3 className="font-semibold mb-2">Privacy first</h3>
+            <p>Your data stays on your machine.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add global NavBar with links
- create Home landing page with hero and feature list
- wire up routes for Home and Upload
- add component and Playwright tests

## Testing
- `npm run test:unit`
- `npx playwright test` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c9f73da8832b8187b8a81568d1c4