### PR TITLE
Handle independent download URLs on Results page

### DIFF
--- a/frontend/src/pages/Results.tsx
+++ b/frontend/src/pages/Results.tsx
@@ -80,16 +80,24 @@ export default function Results() {
 
   useEffect(() => {
     async function loadUrls() {
-      const [reportRes, summaryRes] = await Promise.all([
+      const [reportResult, summaryResult] = await Promise.allSettled([
         fetch(`/report/${jobId}`),
         fetch(`/download/${jobId}/summary`),
       ]);
-      if (reportRes.ok) {
-        const data = await reportRes.json();
+
+      if (
+        reportResult.status === 'fulfilled' &&
+        reportResult.value.ok
+      ) {
+        const data = await reportResult.value.json();
         setReportUrl(data.url);
       }
-      if (summaryRes.ok) {
-        const data = await summaryRes.json();
+
+      if (
+        summaryResult.status === 'fulfilled' &&
+        summaryResult.value.ok
+      ) {
+        const data = await summaryResult.value.json();
         setSummaryUrl(data.url);
       }
     }
@@ -102,20 +110,16 @@ export default function Results() {
     <main className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Results</h1>
       <div className="flex gap-4">
-        <a
-          href={summaryUrl ?? '#'}
-          className={linkClasses}
-          download
-        >
-          Download Summary
-        </a>
-        <a
-          href={reportUrl ?? '#'}
-          className={linkClasses}
-          download
-        >
-          Download Report
-        </a>
+        {summaryUrl && (
+          <a href={summaryUrl} className={linkClasses} download>
+            Download Summary
+          </a>
+        )}
+        {reportUrl && (
+          <a href={reportUrl} className={linkClasses} download>
+            Download Report
+          </a>
+        )}
       </div>
 
       <ReportViewer url={reportUrl} />


### PR DESCRIPTION
## Summary
- fetch report and summary URLs independently so one failure doesn't block the other
- show download links only when their URLs are available

## Testing
- `npm test` *(fails: 2 failing Cypress specs)*

------
https://chatgpt.com/codex/tasks/task_e_68aae94cf220832bb6e6b070007f26c8