### PR TITLE
test: navigate to upload page in journey spec

### DIFF
--- a/frontend/cypress/journey.spec.ts
+++ b/frontend/cypress/journey.spec.ts
@@ -6,6 +6,8 @@ describe('user can upload file and reach results', () => {
     cy.intercept('GET', '/rules', ['rule one']);
     cy.visit('/');
 
+    cy.contains('a', /upload/i).click();
+
     cy.intercept('POST', '/upload', { job_id: '123' }).as('upload');
     let statusCall = 0;
     cy.intercept('GET', '/status/123', (req) => {


### PR DESCRIPTION
## Summary
- navigate from home to upload page before selecting file in Cypress journey test

## Testing
- `npm test` *(fails: 2 of 3 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab15bd7dbc832b90867997190db3b2