### PR TITLE
Fix rules page Cypress test

### DIFF
--- a/frontend/cypress/journey.spec.ts
+++ b/frontend/cypress/journey.spec.ts
@@ -19,8 +19,12 @@ describe('user can upload file and reach results', () => {
       }
     }).as('status');
     cy.intercept('POST', '/classify', {}).as('classify');
-    cy.intercept('GET', '/download/123/summary', { body: 'summary' });
-    cy.intercept('GET', '/download/123/report', { body: 'report' });
+    cy.intercept('GET', '/download/123/summary', {
+      url: '/download/123/summary?sig=s123',
+    });
+    cy.intercept('GET', '/report/123', {
+      url: '/download/123/report?sig=r123',
+    });
     cy.intercept('GET', '/summary/123', {
       totals: { income: 0, expenses: 0, net: 0 },
       categories: [],

--- a/frontend/cypress/rules.spec.ts
+++ b/frontend/cypress/rules.spec.ts
@@ -1,22 +1,26 @@
 describe('rules list', () => {
   it('renders rule details without [object Object]', () => {
-    cy.intercept('GET', '/rules', [
-      {
-        id: 1,
-        user_id: 1,
-        label: 'Food',
-        pattern: 'Coffee',
-        match_type: 'contains',
-        field: 'description',
-        priority: 0,
-        confidence: 1,
-        version: 1,
-        provenance: 'user',
-        updated_at: '2024-01-01T00:00:00Z',
-      },
-    ]);
-    cy.visit('/');
-    cy.get('li')
+    cy.intercept('GET', '/rules', (req) => {
+      if (req.headers['sec-fetch-dest'] === 'empty') {
+        req.reply([
+          {
+            id: 1,
+            user_id: 1,
+            label: 'Food',
+            pattern: 'Coffee',
+            match_type: 'contains',
+            field: 'description',
+            priority: 0,
+            confidence: 1,
+            version: 1,
+            provenance: 'user',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        ]);
+      }
+    });
+    cy.visit('/rules');
+    cy.get('ul li')
       .first()
       .should('contain', 'Coffee')
       .and('contain', 'Food')


### PR DESCRIPTION
## Summary
- Correct rules spec to navigate directly to /rules and target the rule list element
- Stub rule API without intercepting page HTML
- Adjust journey spec download intercepts for expected URLs

## Testing
- `npm run test:unit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab180011d0832ba0c5292affb347a5