### PR TITLE
feat: support configurable frontend dev port

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:5174',
+    baseUrl:
+      process.env.CYPRESS_BASE_URL ||
+      `http://localhost:${process.env.PORT || 5174}`,
     supportFile: false,
     specPattern: 'cypress/**/*.spec.ts',
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --port 5174",
+    "dev": "PORT=${PORT:-5174} vite --port $PORT",
     "build": "vite build",
     "preview": "vite preview",
     "cypress:run": "cypress run",
-    "test": "CYPRESS_BASE_URL=http://localhost:5174 start-server-and-test dev http://localhost:5174 cypress:run",
+    "test": "PORT=${PORT:-5174} CYPRESS_BASE_URL=http://localhost:$PORT start-server-and-test dev http://localhost:$PORT cypress:run",
     "test:unit": "vitest run"
   },
   "dependencies": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,14 +1,16 @@
 import { defineConfig } from '@playwright/test';
 
+const port = Number(process.env.PORT) || 5174;
+
 export default defineConfig({
   testDir: './playwright',
   use: {
-    baseURL: 'http://localhost:5174',
+    baseURL: `http://localhost:${port}`,
     headless: true,
   },
   webServer: {
     command: 'npm run dev',
-    port: 5174,
+    port,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true, // or '0.0.0.0'
-    port: 5174,
-    strictPort: true,
+    port: Number(process.env.PORT) || 5174,
+    strictPort: false,
     allowedHosts,
   },
   test: {


### PR DESCRIPTION
## Summary
- make Vite dev server use PORT env with fallback and allow automatic port fallback
- forward PORT to dev and test scripts and reference CYPRESS_BASE_URL
- read PORT in Cypress and Playwright configs

## Testing
- `PORT=5175 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab527241f4832b8d717602210e31b0