### PR TITLE
Fix frontend test port reference

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "cypress:run": "cypress run",
-    "test": "PORT=${PORT:-5174} CYPRESS_BASE_URL=http://localhost:$PORT start-server-and-test dev http://localhost:$PORT cypress:run",
+    "test": "PORT=${PORT:-5174} CYPRESS_BASE_URL=http://localhost:${PORT:-5174} start-server-and-test dev http://localhost:${PORT:-5174} cypress:run",
     "test:unit": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure frontend test script always includes the configured PORT

## Testing
- `npm test` *(fails: Cypress failed to start: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c987de0832b96faeaa59a5a752e