### PR TITLE
feat(frontend): enforce strict dev port

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "PORT=${PORT:-5174} vite --port $PORT",
+    "dev": "PORT=${PORT:-5174} vite --strictPort --port $PORT",
     "build": "vite build",
     "preview": "vite preview",
     "cypress:run": "cypress run",


### PR DESCRIPTION
## Summary
- fail vite dev if port is in use by adding `--strictPort`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9beb0df70832baae1adbb0df58260