### PR TITLE
Ensure frontend tests launch on a free port

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "autoprefixer": "^10.4.14",
         "cypress": "^13.7.3",
         "jsdom": "^26.1.0",
+        "kill-port": "^2.0.1",
         "postcss": "^8.4.31",
         "start-server-and-test": "^2.0.13",
         "tailwindcss": "^3.4.4",
@@ -3747,6 +3748,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -4624,6 +4632,20 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "node_modules/kill-port": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-2.0.1.tgz",
+      "integrity": "sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-them-args": "1.3.2",
+        "shell-exec": "1.0.2"
+      },
+      "bin": {
+        "kill-port": "cli.js"
       }
     },
     "node_modules/lazy-ass": {
@@ -6126,6 +6148,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "cypress:run": "cypress run",
-    "test": "PORT=${PORT:-5174} CYPRESS_BASE_URL=http://localhost:${PORT:-5174} start-server-and-test dev http://localhost:${PORT:-5174} cypress:run",
+    "test": "PORT=${PORT:-5174} CYPRESS_BASE_URL=http://localhost:${PORT:-5174} bash -c 'npx kill-port $PORT && start-server-and-test dev http://localhost:$PORT cypress:run'",
     "test:unit": "vitest run"
   },
   "dependencies": {
@@ -30,6 +30,7 @@
     "autoprefixer": "^10.4.14",
     "cypress": "^13.7.3",
     "jsdom": "^26.1.0",
+    "kill-port": "^2.0.1",
     "postcss": "^8.4.31",
     "start-server-and-test": "^2.0.13",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary
- Kill any process bound to the Vite dev port before running tests
- Add `kill-port` dev dependency

## Testing
- `npm test` *(fails: /root/.cache/Cypress/13.7.3/Cypress/Cypress: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c41b3654832ba597eff26a285217