### PR TITLE
Ensure UserRule user_id indexed and required

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -19,7 +19,7 @@ class ProcessingJob(SQLModel, table=True):
 
 class UserRule(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
-    user_id: Optional[int] = None
+    user_id: int = Field(..., nullable=False, index=True)
     label: str
     pattern: str
     match_type: str = "contains"

--- a/tests/test_rule_validation.py
+++ b/tests/test_rule_validation.py
@@ -37,7 +37,7 @@ def client_fixture():
 
 
 def test_create_rule_rejects_short_pattern(client: TestClient):
-    resp = client.post("/rules", json={"label": "x", "pattern": "abcde"})
+    resp = client.post("/rules", json={"user_id": 1, "label": "x", "pattern": "abcde"})
     assert resp.status_code == 400
 
 


### PR DESCRIPTION
## Summary
- require non-null indexed `user_id` on `UserRule`
- update tests to include explicit `user_id` when creating rules

## Testing
- `poetry run ruff check backend/models.py tests/test_backend_api.py tests/test_rule_validation.py`
- `poetry run pytest`
- `python - <<'PY'
import os, json
from fastapi.testclient import TestClient
from backend.app import app
os.environ['AUTH_BYPASS'] = '1'
with TestClient(app) as client:
    content = json.dumps({"description": "Coffee Shop", "type": "debit"})
    job_id = client.post('/upload', data=content, headers={'Content-Type':'application/x-ndjson'}).json()['job_id']
    resp = client.post('/classify', json={'job_id': job_id, 'user_id': 1})
    print('status', resp.status_code)
    data = resp.json()
    print('keys', list(data.keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc22667a0c832b9732a73c6509201c