### PR TITLE
fix: supply user id when creating BDD rule

### DIFF
--- a/features/steps/backend_api_steps.py
+++ b/features/steps/backend_api_steps.py
@@ -70,7 +70,7 @@ def then_job_status(context, status):
 
 @when('I create a rule "{text}"')
 def when_create_rule(context, text):
-    context.client.post("/rules", json={"label": text, "pattern": text})
+    context.client.post("/rules", json={"user_id": 1, "label": text, "pattern": text})
 
 
 @then('the rules list contains "{text}"')


### PR DESCRIPTION
## Summary
- include `user_id` when creating a rule in backend BDD steps so rule creation succeeds

## Testing
- `poetry run pytest`
- `poetry run behave`


------
https://chatgpt.com/codex/tasks/task_e_68bc2136d0e8832b98d2ac46416ffff2